### PR TITLE
TEIID-4505  clarify docs that the pkFieldName must match a get/set method

### DIFF
--- a/admin/Infinispan_HotRod_Data_Sources.adoc
+++ b/admin/Infinispan_HotRod_Data_Sources.adoc
@@ -32,7 +32,7 @@ The following property is required as it provides the mapping to the Infinispan 
 |===
 |Property Name |Property Template|Description
 
-| CacheTypeMap |cacheName:className[;pkFieldName[:cacheKeyJavaType]]  | For the indicated cacheName, map the root Java Object (pojo) class name.  Optionally, but required for updates, identify which class attribute is the primary key to the cache.  Optionally, identify primary key java type when different than class attribute type 
+| CacheTypeMap |cacheName:className[;pkFieldName[:cacheKeyJavaType]]  | For the indicated cacheName, map the root Java Object (pojo) class name.  Optionally, but required for updates, identify which class attribute is the primary key to the cache.  The pkFieldName *MUST* match a corresponding getter/setter method in the pojo.  Optionally, identify primary key java type when different than class attribute type 
 |===
 
 === *JDG Schema using Protobuf Definition and Marshaller(s)*

--- a/admin/Infinispan_Library_Mode_Data_Sources.adoc
+++ b/admin/Infinispan_Library_Mode_Data_Sources.adoc
@@ -39,7 +39,7 @@ The following are the required properties:
 |===
 |Property Name |Property Template|Description
 
-| CacheTypeMap |cacheName:className[;pkFieldName[:cacheKeyJavaType]]  | For the indicated cache, map the root Java Object class name.  Optionally, but required for updates, identify which class attribute is the primary key to the cache. Identify primary key java type when different than class attribute type 
+| CacheTypeMap |cacheName:className[;pkFieldName[:cacheKeyJavaType]]  | For the indicated cache, map the root Java Object class name.  Optionally, but required for updates, identify which class attribute is the primary key to the cache.  The pkFieldName *MUST* match a corresponding getter/setter method in the pojo. Identify primary key java type when different than class attribute type 
 |===
 
 The following are the property options for defining how the CacheManager will be created/accessed:


### PR DESCRIPTION
TEIID-4505  clarify docs that the pkFieldName must match a getter/setter method in the pojo