### PR TITLE
Proper label for the Function ST_GeomFromEWKT

### DIFF
--- a/reference/Spatial_Functions.adoc
+++ b/reference/Spatial_Functions.adoc
@@ -66,7 +66,7 @@ ST_GeomFromEWKB(bin)
 
 bin is a blob. Return value is a geography.  Only 2 dimensions are supported.
 
-=== ST_GeomFromText
+=== ST_GeomFromEWKT
 
 Returns a geometry from a Clob in EWKT format.
 


### PR DESCRIPTION
ST_GeomFromText was used as a Label for ST_GeomFromEWKT.