### PR TITLE
Fix Javadoc 11 links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,7 @@ Once the pull request is committed the published content will be updated automat
 You may need test locally, to make sure the changes are correct, to do this install https://github.com/GitbookIO/gitbook[gitbook], then execute the following commands from the checkout location:
 
 ----
+$ cd wildfly
 $ gitbook install
 $ gitbook serve -w
 ----

--- a/client-dev/Connecting_to_a_Teiid_Server.adoc
+++ b/client-dev/Connecting_to_a_Teiid_Server.adoc
@@ -32,8 +32,8 @@ You can also obtain the {{ book.productnameFull }} JDBC from the Maven Repositor
 
 Important classes in the client JAR:
 
-* `org.teiid.jdbc.TeiidDriver`- allows JDBC connections using the {{ book.javaVersionUrl }}/docs/api/java/sql/DriverManager.html[DriverManager] class.
-* `org.teiid.jdbc.TeiidDatasource`- allows JDBC connections using the {{ book.javaVersionUrl }}/docs/api/javax/sql/DataSource.html[DataSource] {{ book.javaVersionUrl }}/docs/api/javax/sql/XADataSource.html[XADataSource] class. You should use this class to create managed or XA connections.
+* `org.teiid.jdbc.TeiidDriver`- allows JDBC connections using the {{ book.javaVersionUrl }}/docs/api/java.sql/java/sql/DriverManager.html[DriverManager] class.
+* `org.teiid.jdbc.TeiidDatasource`- allows JDBC connections using the {{ book.javaVersionUrl }}/docs/api/java.sql/javax/sql/DataSource.html[DataSource] {{ book.javaVersionUrl }}/docs/api/java.sql/javax/sql/XADataSource.html[XADataSource] class. You should use this class to create managed or XA connections.
 
 Once you have established a connection with the {{ book.productnameFull }} Server, you can use standard JDBC API classes to interrogate metadata and execute queries.
 

--- a/reference/Date_Time_Functions.adoc
+++ b/reference/Date_Time_Functions.adoc
@@ -3,7 +3,7 @@
 
 Date and time functions return or operate on dates, times, or timestamps.
 
-Parse and format Date/Time functions use the convention established within the java.text.SimpleDateFormat class to define the formats you can use with these functions. You can learn more about how this class defines formats by visiting the {{ book.javaVersionUrl }}/docs/api/java/text/SimpleDateFormat.html[Javadocs for SimpleDateFormat].
+Parse and format Date/Time functions use the convention established within the java.text.SimpleDateFormat class to define the formats you can use with these functions. You can learn more about how this class defines formats by visiting the {{ book.javaVersionUrl }}/docs/api/java.base/java/text/SimpleDateFormat.html[Javadocs for SimpleDateFormat].
 
 |===
 |Function |Definition |Datatype Constraint
@@ -224,7 +224,7 @@ of the integer range from a pushed down timestampdiff.
 
 == Parsing Date Datatypes from Strings
 
-{{ book.productnameFull }} does not implicitly convert strings that contain dates presented in different formats, such as '19970101' and '31/1/1996' to date-related datatypes. You can, however, use the parseDate, parseTime, and parseTimestamp functions, described in the next section, to explicitly convert strings with a different format to the appropriate datatype. These functions use the convention established within the java.text.SimpleDateFormat class to define the formats you can use with these functions. You can learn more about how this class defines date and time string formats by visiting the http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html[Javadocs for SimpleDateFormat]. Note that the format strings will be locale specific to your Java default locale.
+{{ book.productnameFull }} does not implicitly convert strings that contain dates presented in different formats, such as '19970101' and '31/1/1996' to date-related datatypes. You can, however, use the parseDate, parseTime, and parseTimestamp functions, described in the next section, to explicitly convert strings with a different format to the appropriate datatype. These functions use the convention established within the java.text.SimpleDateFormat class to define the formats you can use with these functions. You can learn more about how this class defines date and time string formats by visiting the {{ book.javaVersionUrl }}/docs/api/java.base/java/text/SimpleDateFormat.html[Javadocs for SimpleDateFormat]. Note that the format strings will be locale specific to your Java default locale.
 
 For example, you could use these function calls, with the formatting string that adheres to the java.text.SimpleDateFormat convention, to parse strings and return the datatype you need:
 

--- a/reference/JDBC_Translators.adoc
+++ b/reference/JDBC_Translators.adoc
@@ -170,7 +170,7 @@ to a 0-argument {{ book.productnameFull }} function name_nextval.
 |false
 |===
 
-[1] JavaDoc for {{ book.javaVersionUrl }}/docs/api/java/sql/DatabaseMetaData.html[DatabaseMetaData] +
+[1] JavaDoc for {{ book.javaVersionUrl }}/docs/api/java.sql/java/sql/DatabaseMetaData.html[DatabaseMetaData] +
 [2] The fully qualified name for exclusion is based upon the settings of the translator and the particulars of the database. All of the applicable name parts used by the translator settings (see useQualifiedName and useCatalogName) including catalog, schema, table will be combined as catalogName.schemaName.tableName with no quoting. For example Oracle does not report a catalog, so the name used with default settings for comparison would be just schemaName.tableName.
 
 WARNING: The default import settings will crawl all available metadata. This import process is time consuming and full metadata import is not needed in most situations. Most commonly you’ll want to limit the import by at least schemaName or schemaPattern and tableTypes.

--- a/reference/Numeric_Functions.adoc
+++ b/reference/Numeric_Functions.adoc
@@ -176,7 +176,7 @@ It will only effect the random values returned by the {{ book.productnameFull }}
 
 == Parsing Numeric Datatypes from Strings
 
-{{ book.productnameFull }} offers a set of functions you can use to parse numbers from strings. For each string, you need to provide the formatting of the string. These functions use the convention established by the java.text.DecimalFormat class to define the formats you can use with these functions. You can learn more about how this class defines numeric string formats by visiting the Sun Java Web site at the following {{ book.javaVersionUrl }}/docs/api/java/text/DecimalFormat.html[URL for Sun Java].
+{{ book.productnameFull }} offers a set of functions you can use to parse numbers from strings. For each string, you need to provide the formatting of the string. These functions use the convention established by the java.text.DecimalFormat class to define the formats you can use with these functions. You can learn more about how this class defines numeric string formats by visiting the {{ book.javaVersionUrl }}/docs/api/java.base/java/text/DecimalFormat.html[Java Documentation Web site].
 
 For example, you could use these function calls, with the formatting string that adheres to the java.text.DecimalFormat convention, to parse strings and return the datatype you need:
 
@@ -211,7 +211,7 @@ For example, you could use these function calls, with the formatting string that
 
 == Formatting Numeric Datatypes as Strings
 
-{{ book.productnameFull }} offers a set of functions you can use to convert numeric datatypes into strings. For each string, you need to provide the formatting. These functions use the convention established within the java.text.DecimalFormat class to define the formats you can use with these functions. You can learn more about how this class defines numeric string formats by visiting the Sun Java Web site at the following {{ book.javaVersionUrl }}/docs/api/java/text/DecimalFormat.html[URL for Sun Java] .
+{{ book.productnameFull }} offers a set of functions you can use to convert numeric datatypes into strings. For each string, you need to provide the formatting. These functions use the convention established within the java.text.DecimalFormat class to define the formats you can use with these functions. You can learn more about how this class defines numeric string formats by visiting the {{ book.javaVersionUrl }}/docs/api/java.base/java/text/DecimalFormat.html[Java Documentation Web site].
 
 For example, you could use these function calls, with the formatting string that adheres to the java.text.DecimalFormat convention, to format the numeric datatypes into strings:
 


### PR DESCRIPTION
Fixes links for Javadoc 11, which includes the packages now. Changes the
`README.adoc` to make clear how to run the documentation locally for
future contributors.