### PR TITLE
Generated anchor IDs for all of the headings in the Client Developer's Guide

### DIFF
--- a/client-dev/ADONET_Integration.adoc
+++ b/client-dev/ADONET_Integration.adoc
@@ -1,7 +1,9 @@
+[id="client-dev-ADONET_Integration-ADONet-Integration"]
 = ADO.Net Integration
 
 link:http://www.npgsql.org/[Npgsql] is an open source ADO.NET Data Provider for PostgreSQL.  It can be integrated with {{ book.productnameFull }} to provide access from programs written in C#, Visual Basic, F#.
 
+[id="client-dev-ADONET_Integration-Prerequisites"]
 == Prerequisites
 
 - Install the Npgsql using the .msi Windows installer.  {{ book.productnameFull }} integration was last tested with version 3.2.6. 
@@ -10,10 +12,12 @@ link:http://www.npgsql.org/[Npgsql] is an open source ADO.NET Data Provider for 
 
 - Have a VDB deployed.
 
+[id="client-dev-ADONET_Integration-Npgsql-Configuration"]
 == Npgsql Configuration
 
 See the link:http://www.npgsql.org/doc/connection-string-parameters.html[documentation] for supported connection parameters.  Not all configuration parameters have been tested for use with {{ book.productnameFull }}.
 
+[id="client-dev-ADONET_Integration-Known-Limitations"]
 == Known Limitations
 
 - link:https://issues.redhat.com/browse/TEIID-5220[TEIID-5220] prevents displaying the metadata of tables and views, but does not affect querying.  Certain tools, such as PowerBi, may have options to turn of the need to perform metadata introspection.

--- a/client-dev/Additional_Socket_Client_Settings.adoc
+++ b/client-dev/Additional_Socket_Client_Settings.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Additional_Socket_Client_Settings-Additional-Socket-Client-Settings"]
 = Additional Socket Client Settings
 
 A "teiid-client-settings.properties" file can be used to configure {{ book.productnameFull }} low level and link:SSL_Client_Connections.html[SSL] socket connection properties. Currently only a single properties file is expected per driver/classloader combination. A sample "teiid-client-settings.properties" file can be found inside the "teiid-<version>-client.jar" file at the root called "teiid-client-settings.orig.properties". To customize the settings, extract this file, make a copy, change the property values accordingly, and place this file in the client application’s classpath before the "teiid-<version>-client.jar" file. Typically clients will not need to adjust the non-SSL properties. For reference the properties are:

--- a/client-dev/Client_Developers_Guide.adoc
+++ b/client-dev/Client_Developers_Guide.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Client_Developers_Guide-Client-Developers-Guide"]
 = Client Developer's Guide
 
 This guide intended for developers that are trying to write 3rd party applications that interact with {{ book.productnameFull }}. This will guide you through connection mechanisms, extensions to JDBC API, ODBC, SSL etc. Before one can delve into {{ book.productnameFull }} it is very important to learn few basic constructs of {{ book.productnameFull }}, like what is VDB? what is Model? etc. For that please read the http://teiid.io/about/basics/[short introduction].

--- a/client-dev/Configuring_the_Data_Source_Name_DSN.adoc
+++ b/client-dev/Configuring_the_Data_Source_Name_DSN.adoc
@@ -1,8 +1,10 @@
 
+[id="client-dev-Configuring_the_Data_Source_Name_DSN-Configuring-the-Data-Source-Name-DSN"]
 = Configuring the Data Source Name (DSN)
 
 See link:ODBC_Support.adoc#_connection_settings[{{ book.productnameFull }} supported options] for a description of the client configuration.
 
+[id="client-dev-Configuring_the_Data_Source_Name_DSN-Windows-Installation"]
 == Windows Installation
 
 Once you have installed the ODBC Driver Client software on your workstation, you have to configure it to connect to a {{ book.productnameFull }} Runtime. Note that the following instructions are specific to the Microsoft Windows Platform.
@@ -40,6 +42,7 @@ image:images/dsnsetup3.png[dsnsetup3.png]
 
 9.  Click "save" and you can optionally click "test" to validate your connection if the {{ book.productnameFull }} is running. You have configured a {{ book.productnameFull }}’s virtual database as a data source for your ODBC applications. Now you can use applications such as Excel, Access to query the data in the VDB
 
+[id="client-dev-Configuring_the_Data_Source_Name_DSN-Other-nix-Platform-Installations"]
 == Other *nix Platform Installations
 
 Before you can access {{ book.productnameFull }} using ODBC on any *nix platforms, you need to either install a ODBC driver manager or verify that one already exists. As the ODBC Driver manager {{ book.productnameFull }} recommends http://www.unixodbc.org/[unixODBC]. If you are working with RedHat Linux or Fedora you can check the graphical "yum" installer to search, find and install unixODBC. Otherwise you can http://www.unixodbc.org/unixODBC-2.3.0.tar.gz[download] the unixODBC manager here. To install, simply untar the contents of the file to a temporary location and execute the following commands as super user.

--- a/client-dev/Connecting_to_a_Teiid_Server.adoc
+++ b/client-dev/Connecting_to_a_Teiid_Server.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Connecting_to_a_Teiid_Server-Connecting-to-a-bookproductnameFull-Server"]
 = Connecting to a {{ book.productnameFull }} Server
 
 The {{ book.productnameFull }} JDBC API provides Java Database Connectivity (JDBC) access to a Virtual Database (VDB) deployed on {{ book.productnameFull }}. The {{ book.productnameFull }} JDBC API is compatible with the JDBC 4.0 specification; however, it does not fully support all methods. Advanced features, such as updatable result sets or SQL3 data types, are not supported.
@@ -37,6 +38,7 @@ Important classes in the client JAR:
 
 Once you have established a connection with the {{ book.productnameFull }} Server, you can use standard JDBC API classes to interrogate metadata and execute queries.
 
+[id="client-dev-Connecting_to_a_Teiid_Server-OpenTracing-Support"]
 == OpenTracing Support
 
 http://opentracing.io/[OpenTracing] support is optional for the client driver.  For remote connections to propagate the span the driver must have the appropriate OpenTracing jars in its classpath.  This can be done via a maven dependency:

--- a/client-dev/Connection_Extensions.adoc
+++ b/client-dev/Connection_Extensions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Connection_Extensions-Connection-Extensions"]
 = Connection Extensions
 
 {{ book.productnameFull }} connections (defined by the `org.teiid.jdbc.TeiidConnection` interface) support the changeUser method to reauthenticate a given connection. If the reauthentication is successful the current connection my be used with the given identity. Existing statements/result sets are still available for use under the old identity. 

--- a/client-dev/DSN_Less_Connection.adoc
+++ b/client-dev/DSN_Less_Connection.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-DSN_Less_Connection-DSN-Less-Connection"]
 = DSN Less Connection
 
 You can also connect to {{ book.productnameFull }} VDB using ODBC with out explicitly creating a DSN. However, in these scenarios your application needs, what is called as "DSN less connection string". The below is a sample connection string

--- a/client-dev/DataSource_Connection.adoc
+++ b/client-dev/DataSource_Connection.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-DataSource_Connection-DataSource-Connection"]
 = DataSource Connection
 
 To use a data source based connection, use `org.teiid.jdbc.TeiidDataSource` as the data source class. The `{{ book.productnameFull }}DataSource` is also an XADatasource. {{ book.productnameFull }} DataSource class is also Serializable, so it possible for it to be used with JNDI naming services.

--- a/client-dev/Driver_Connection.adoc
+++ b/client-dev/Driver_Connection.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Driver_Connection-Driver-Connection"]
 = Driver Connection
 
 Use *org.teiid.jdbc.TeiidDriver* as the driver class.
@@ -25,6 +26,7 @@ URL Components
 NOTE: host and port may be a comma separated list to specify link:Using_Multiple_Hosts.adoc[multiple hosts].
 {% endif %}
 
+[id="client-dev-Driver_Connection-Local-Connections"]
 == Local Connections
 
 To make a in-VM connection, omit the protocol and host/port: jdbc:teiid:vdb-name;props
@@ -33,6 +35,7 @@ To make a in-VM connection, omit the protocol and host/port: jdbc:teiid:vdb-name
 For local WildFly deployments it's preferred to configure the link:WildFly_DataSource.adoc[DataSource] as an in-VM rather than socket based connection.
 {% endif %}
 
+[id="client-dev-Driver_Connection-URL-Connection-Properties"]
 == URL Connection Properties
 
 The following table shows all the supported connection properties that can used with {{ book.productnameFull }} JDBC Driver URL connection string, or on the {{ book.productnameFull }} JDBC Data Source class.

--- a/client-dev/Execution_Properties.adoc
+++ b/client-dev/Execution_Properties.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Execution_Properties-Execution-Properties"]
 = Execution Properties
 
 Execution properties may be set on a per statement basis through the `{{ book.productnameFull }}Statement` interface or on the connection via the link:SET_Statement.adoc[SET Statement]. For convenience, the property keys are defined by constants on the `org.teiid.jdbc.ExecutionProperties` interface.

--- a/client-dev/GeoServer_Integration.adoc
+++ b/client-dev/GeoServer_Integration.adoc
@@ -1,7 +1,9 @@
+[id="client-dev-GeoServer_Integration-GeoServer-Integration"]
 = GeoServer Integration
 
 link:http://geoserver.org/[GeoServer] is an open source server for geospatial data.  It can be integrated with {{ book.productnameFull }} to serve geospatial data from a variety of sources.
 
+[id="client-dev-GeoServer_Integration-Prerequisites"]
 == Prerequisites
 
 - Have GeoServer installed.  By default this will be in a different container than the {{ book.productnameFull }} WildFly instance, but it should be possible to
@@ -14,6 +16,7 @@ deploy into the same WildFly instance.  {{ book.productnameFull }} integration w
 geometry columns have the appropriate srid and coord_dimensions, which may require setting the {http://www.teiid.org/translator/spatial/2015}srid and {http://www.teiid.org/translator/spatial/2015}coord_dimension
 extension property on the geometry column. 
 
+[id="client-dev-GeoServer_Integration-GeoServer-Configuration"]
 == GeoServer Configuration
 
 This process will need to be repeated for each VDB schema you are exposing that contains geospatial data.
@@ -30,6 +33,7 @@ configure just this GeoServer connection pool.
 .. Note that the PostGIS function ST_Estimated_Extent is not supported by {{ book.productnameFull }} and the execution will be shown in the logs as an error
 when selecting to compute the bounding box from the data.  
 
+[id="client-dev-GeoServer_Integration-Additional-Considerations"]
 == Additional Considerations
 
 - If you are integrating a PostgreSQL source, you must not re-expose the geometry_columns or geography_columns tables.

--- a/client-dev/Installing_the_ODBC_Driver_Client.adoc
+++ b/client-dev/Installing_the_ODBC_Driver_Client.adoc
@@ -1,8 +1,10 @@
 
+[id="client-dev-Installing_the_ODBC_Driver_Client-Installing-the-ODBC-Driver-Client"]
 = Installing the ODBC Driver Client
 
 A PostgreSQL ODBC driver needed to make the ODBC connection to {{ book.productnameFull }} is _not_ bundled with the {{ book.productnameFull }} distribution. The appropriate driver needs be http://www.postgresql.org/ftp/odbc/versions/[downloaded] directly from the PostgreSQL web site. The _8.04.200_ version of the ODBC driver was extensively tested for compatibility.
 
+[id="client-dev-Installing_the_ODBC_Driver_Client-Microsoft-Windows"]
 == Microsoft Windows
 
 1.  Download at least the ODBC 8.4 driver from the http://ftp.postgresql.org/pub/odbc/versions/msi[PostgreSQL download site]. If you are looking for 64-bit Windows driver download the driver from http://code.google.com/p/visionmap/wiki/psqlODBC[here]. Later versions of the driver may be used the 9.0-9.5 clients have been used extensively by the {{ book.productnameFull }} community.  There are no active issues against 9.6 and later, but they have not yet seen as much use - if you encounter an issue, please create a JIRA.
@@ -34,6 +36,7 @@ image:images/winsetup5.png[winsetup5.png]
 
 Click "Finish" to complete.
 
+[id="client-dev-Installing_the_ODBC_Driver_Client-Other-nix-Platform-Installations"]
 == Other *nix Platform Installations
 
 For all other platforms other than Microsoft Windows, the ODBC driver needs built from the source files provided. Download the ODBC driver source files from http://wwwmaster.postgresql.org/download/mirrors-ftp/odbc/versions/src/psqlodbc-08.04.0200.tar.gz[the PostgreSQL download site]. Untar the files to a temporary location. For example: "~/tmp/pgodbc". Build and install the driver by running the commands below.

--- a/client-dev/JDBC_Extensions.adoc
+++ b/client-dev/JDBC_Extensions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-JDBC_Extensions-JDBC-Extensions"]
 = JDBC Extensions
 
 These are custom extensions to JDBC API from {{ book.productnameFull }} to support various features.

--- a/client-dev/JDBC_Support.adoc
+++ b/client-dev/JDBC_Support.adoc
@@ -1,10 +1,12 @@
 
+[id="client-dev-JDBC_Support-JDBC-Support"]
 = JDBC Support
 
 {{ book.productnameFull }} provides a robust JDBC driver that implements most of the JDBC API according to the latest specification and supported Java version. Most tooling designed to work with JDBC should work seamlessly with the {{ book.productnameFull }} driver. When in doubt, see link:Unsupported_JDBC_Methods.adoc[Unsupported JDBC Methods] for functionality that has yet to be implemented.
 
 If you’re needs go beyond JDBC, {{ book.productnameFull }} has also provided link:JDBC_Extensions.adoc[JDBC Extensions] for asynch handling, federation, and other features.
 
+[id="client-dev-JDBC_Support-Generated-Keys"]
 == Generated Keys
 
 {{ book.productnameFull }} supports returning generated keys for JDBC sources and from {{ book.productnameFull }} temp tables with SERIAL primary key columns. However the current implementation will return only the last set of keys generated and will return the key results directly from the source - no view projection of other intermediate handling is performed. For most scenarios (single source inserts) this handling is sufficient. A custom solution may need to be developed if you are using a FOR EACH ROW instead of trigger to process your inserts and target multiple tables that each return generated keys. It is possible to develop a UDF that also manipulates the returned generated keys - see the `org.teiid.CommandContext` methods dealing with generated keys for more.

--- a/client-dev/Local_Transactions.adoc
+++ b/client-dev/Local_Transactions.adoc
@@ -1,8 +1,10 @@
 
+[id="client-dev-Local_Transactions-Local-Transactions"]
 = Local Transactions
 
 A Local transaction from a client perspective affects only a single resource, but can coordinate multiple statements.
 
+[id="client-dev-Local_Transactions-JDBC-Specific"]
 == JDBC Specific
 
 The `Connection` class uses the `autoCommit` flag to explicitly control local transactions. By default, autoCommit is set to `true`, which indicates request level or implicit transaction control. 
@@ -45,6 +47,7 @@ Any of the following operations will end a local transaction:
 3.  Connection.rollback()
 4.  A transaction will be rolled back automatically if it times out.
 
+[id="client-dev-Local_Transactions-Turning-Off-JDBC-Local-Transaction-Controls"]
 === Turning Off JDBC Local Transaction Controls
 
 In some cases, tools or frameworks above {{ book.productnameFull }} will call setAutoCommit(false), commit() and rollback() even when all access is read-only and no transactions are necessary. In the scope of a local transaction {{ book.productnameFull }} will start and attempt to commit an XA transaction, possibly complicating configuration or causing performance degradation.
@@ -58,6 +61,7 @@ disableLocalTxn=true
 
 TIP: Turning off local transactions can be dangerous and can result in inconsistent results (if reading data) or inconsistent data in data stores (if writing data). For safety, this mode should be used only if you are certain that the calling application does not need local transactions.
 
+[id="client-dev-Local_Transactions-Transaction-Statements"]
 == Transaction Statements
 
 Transaction control statements, which are also applicable to ODBC clients, explicitly control the local transaction boundaries. The relevant statements are:

--- a/client-dev/Node_Integration.adoc
+++ b/client-dev/Node_Integration.adoc
@@ -1,7 +1,9 @@
+[id="client-dev-Node_Integration-Nodejs-Integration"]
 = Node.js Integration
 
 link:https://nodejs.org[Node.js] is an open source event driven runtime that can be integrated with {{ book.productnameFull }}.
 
+[id="client-dev-Node_Integration-Prerequisites"]
 == Prerequisites
 
 - Have Node.js installed.  The npm pagckage pg is also required.  Use "
@@ -9,6 +11,7 @@ link:https://nodejs.org[Node.js] is an open source event driven runtime that can
 - Your {{ book.productnameFull }} installation should already be setup for link:../admin/Socket_Transports.adoc[ODBC] access.  This allows the optional support of Node.js 
 for PostGIS/PostgreSQL to be used.
 
+[id="client-dev-Node_Integration-Usage"]
 == Usage
 
 For example if you have VDB called "northwind" deployed on your {{ book.productnameFull }} server, and it has table called "customers" and you are using default configuration such as

--- a/client-dev/Non-blocking_Statement_Execution.adoc
+++ b/client-dev/Non-blocking_Statement_Execution.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Non-blocking_Statement_Execution-Non-blocking-Statement-Execution"]
 = Non-blocking Statement Execution
 
 JDBC query execution can indefinitely block the calling thread when a statement is executed or a resultset is being iterated. In some situations you may not wish to have your calling threads held in these blocked states. When using embedded/local connections, you may optionally use the `org.teiid.jdbc.TeiidStatement` and `org.teiid.jdbc.TeiidPreparedStatement` interfaces to execute queries with a callback `org.teiid.jdbc.StatementCallback` that will be notified of statement events, such as an available row, an exception, or completion. Your calling thread will be free to perform other work. The callback will be executed by an engine processing thread as needed. If your results processing is itself blocking and you want query processing to be concurrent with results processing, then your callback should implement onRow handling in a multi-threaded manner to allow the engine thread to continue.
@@ -31,6 +32,7 @@ The non-blocking logic is limited to statement execution only. Other JDBC operat
 
 If you access forward positions in the onRow method (calling next, isLast, isAfterLast, absolute), they may not yet be valid and a `org.teiid.jdbc.AsynchPositioningException` will be thrown. That exception is recoverable if caught or can be avoided by calling `{{ book.productnameFull }}ResultSet.available()` to determine if your desired positioning will be valid.
 
+[id="client-dev-Non-blocking_Statement_Execution-Continuous-Execution"]
 == Continuous Execution
 
 The `RequestOptions` object may be used to specify a special type of continuous asynch execution via the `continuous` or `setContinuous` methods. In continuous mode the statement will be continuously re-executed. This is intended for consuming real-time or other data streams processed through a SQL plan. A continuous query will only terminate on an error or when the statement is explicitly closed. The SQL for a continuous query is no different than any other statement. Care should be taken to ensure that retrievals from non-continuous sources is appropriately cached for reuse, such as by using materialized views or session scoped temp tables.

--- a/client-dev/ODBC_Connection_Properties.adoc
+++ b/client-dev/ODBC_Connection_Properties.adoc
@@ -1,3 +1,4 @@
+[id="client-dev-ODBC_Connection_Properties-Configuring-Connection-Properties-with-ODBC"]
 = Configuring Connection Properties with ODBC
 
 When working with ODBC connection, the user can set the connection properties link:Driver_Connection.adoc[Driver Connection#URL Connection Properties] 

--- a/client-dev/ODBC_Support.adoc
+++ b/client-dev/ODBC_Support.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-ODBC_Support-ODBC-Support"]
 = ODBC Support
 
 Open Database Connectivity (ODBC) is a standard database access method developed by the SQL Access group in 1992. ODBC, just like JDBC in Java, allows consistent client access regardless of which database management system (DBMS) is handling the data. ODBC uses a driver to translate the application’s data queries into commands that the DBMS understands. For this to work, both the application and the DBMS must be ODBC-compliant – that is, the application must be capable of issuing ODBC commands and the DBMS must be capable of responding to them.
@@ -18,6 +19,7 @@ Postgres ODBC drivers 9.5 and later do not require this special property as the 
 
 Compatibility was last ensured with the 9.6 Postgres ODBC driver.  You are encouraged to use later client versions when needed and report any issues to the community.
 
+[id="client-dev-ODBC_Support-Known-Limitations"]
 == Known Limitations:
 
 * Updateable cursors are not supported. You will receive parsing errors containing the pg system column ctid if this feature is not disabled.
@@ -25,6 +27,7 @@ Compatibility was last ensured with the 9.6 Postgres ODBC driver.  You are encou
 * The {{ book.productnameFull }} object type will map to the PostgreSQL UNKNOWN type, which cannot be serialized by the ODBC layer. Cast/Convert should be used to provide a type hint when appropriate - for example teiid_session_set returns an object value. "SELECT teiid_session_set('x', 'y')" will fail, but "SELECT cast(teiid_session_set('x', 'y') as string)" will succeed.
 * Multi-dimensional arrays are not supported.
 
+[id="client-dev-ODBC_Support-Installation"]
 == Installation
 
 Before an application can use ODBC, you must first install the ODBC
@@ -36,6 +39,7 @@ your {{ book.productnameFull }} VDB.
 For a windows client, see the link:Installing_the_ODBC_Driver_Client.adoc[Windows Installation Guide].
 {% endif %}
 
+[id="client-dev-ODBC_Support-Configuration"]
 == Configuration
 
 WARNING: By default {{ book.productnameFull }} supports plain text password authentication for pg/ODBC. If the client/server are not configured to use SSL or GSS authentication, the password will be sent in plain text over the network. 
@@ -50,6 +54,7 @@ For a windows client, see the link:Configuring_the_Data_Source_Name_DSN.adoc[Con
 
 See also link:DSN_Less_Connection.adoc[DSN Less Connection].
 
+[id="client-dev-ODBC_Support-Connection-Settings"]
 === Connection Settings
 
 All the available pg driver connection options with their descriptions that can be used are defined here https://odbc.postgresql.org/docs/config.html. When using these properties on the connection string, their property names are defined here https://odbc.postgresql.org/docs/config-opt.html.
@@ -79,6 +84,7 @@ Settings that manipulate datatypes, metadata, or optimizations such as "Show Sys
 
 Any other setting that does have a client side affect, such as "LF <-> CR/LF conversion", may be used if desired but there is currently no server side usage of the setting.
 
+[id="client-dev-ODBC_Support--bookproductnameFull-Connection-Settings"]
 ==== {{ book.productnameFull }} Connection Settings
 
 Most {{ book.productnameFull }} specific connection properties do not map to ODBC client connection settings. If you find yourself in this situation and cannot use post connection SET statements, then the VDB itself may take default link:ODBC_Connection_Properties.adoc[connection properties] for ODBC. Use VDB properties of the form connection.XXX to control things like partial results mode, result set caching, etc.

--- a/client-dev/OData4_Support.adoc
+++ b/client-dev/OData4_Support.adoc
@@ -1,10 +1,12 @@
 
+[id="client-dev-OData4_Support-OData-Version-40-Support"]
 = OData Version 4.0 Support
 :toc: manual
 :toc-placement: preamble
 
 {{ book.productnameFull }} strives to be compliant with the OData specification.  The rest of this chapter highlight some specifics of OData and {{ book.productnameFull }}'s support, but you should also consult http://www.odata.org/documentation/[the specification].
 
+[id="client-dev-OData4_Support-How-to-Access-the-data"]
 == How to Access the data?
 
 For example, if you have a vdb by name _northwind_ deployed that has a _customers_ table in a _NW_ model, then you can access that table with an HTTP GET via the URL:
@@ -29,6 +31,7 @@ NOTE: Use correct case (upper or lower) in the resource path.  Unlike SQL, the n
 
 The returned results from OData query can be in Atom/AtomPub XML or JSON format. JSON results are returned by default.
 
+[id="client-dev-OData4_Support-Query-Basics"]
 == Query Basics
 
 Users can submit predicates with along their query to filter the results:
@@ -79,6 +82,7 @@ SELECT o.* FROM NW.orders o join NW.customers c on o.customer_id = c.id where c.
 
 NOTE: *More Comprehensive Documentation about ODATA* - For detailed protocol access you can read the specification at http://odata.org[http://odata.org]. You can also read this very useful web resource http://msdn.microsoft.com/en-us/library/ff478141.aspx[for an example] of accessing an OData server.
 
+[id="client-dev-OData4_Support-How-to-execute-a-stored-procedure"]
 === How to execute a stored procedure?
 Odata allows you to call your exposed stored procedure methods via odata.
 
@@ -86,6 +90,7 @@ Odata allows you to call your exposed stored procedure methods via odata.
 http://localhost:8080/{{ book.odataContext }}/getcustomersearch(id=120,firstname='micheal')
 ----
 
+[id="client-dev-OData4_Support-Not-seeing-all-the-rows"]
 === Not seeing all the rows?
 
 See the link:#_configuration[configuration section] below for more details. Generally batching is being utilized, which tooling should understand automatically, and additional queries with a $skiptoken query option specified are needed:
@@ -95,6 +100,7 @@ See the link:#_configuration[configuration section] below for more details. Gene
 http://localhost:8080/{{ book.odataContext }}/customers?$skiptoken=xxx
 ----
 
+[id="client-dev-OData4_Support-EntitySet-Not-Found-error"]
 === "EntitySet Not Found" error?
 
 When you issue the above query are you seeing a message similar to below?
@@ -108,6 +114,7 @@ Then, it means that either you supplied the model-name/table-name combination wr
 
 It is possible that the entity is not part of the link:#_odata_metadata[metadata], such as when a table does not have any PRIMARY KEY or UNIQUE KEY(s).
 
+[id="client-dev-OData4_Support-How-to-update-your-data"]
 == How to update your data?
 
 Using the OData protocol it is possible to perform CREATE/UPDATE/DELETE operations along with READ operations shown above. These operations use different HTTP methods.
@@ -161,6 +168,7 @@ Accept: application/json
 ----
 
 {% if book.targetWildfly %}
+[id="client-dev-OData4_Support-Security"]
 == Security
 
 By default OData access is secured using HTTPBasic authentication. The user will be authenticated against {{ book.productnameFull }}’s default security domain "teiid-security".
@@ -170,6 +178,7 @@ However, if you wish to change the security domain use a deployment-overlay to o
 OData WAR can also support Kerberos, SAML and OAuth2 authentications, for configuring the these security schemes please see link:../security/Security_Guide.adoc[Security Guide]
 {% endif %}
 
+[id="client-dev-OData4_Support-Configuration"]
 == Configuration
 
 {% if book.targetSpring %}
@@ -245,6 +254,7 @@ deployment-overlay add --name=myOverlay --content=/WEB-INF/web.xml=/modified/web
 
 {{ book.productnameFull }} OData server implements cursoring logic when the result rows exceed the configured batch size. On every request, only _batch-size_ number of rows are returned. Each such request is considered an active cursor, with a specified amount of idle time specified by _skip-token-cache-time_. After the cursor is timed out, the cursor will be closed and remaining results will be cleaned up, and will no longer be available for further queries. Since there is no session based tracking of these cursors, if the request for skiptoken comes after the expired time, the original query will be executed again and tries to reposition the cursor to relative absolute position, however the results are not guaranteed to be same as the underlying sources may have been updated with new information meanwhile.
 
+[id="client-dev-OData4_Support-Limitations"]
 == Limitations
 
 The following feature limitations currently apply.
@@ -254,6 +264,7 @@ The following feature limitations currently apply.
 * data-aggregation extension to specification is not supported.
 * $it usage is limited to only primitive collection properties
 
+[id="client-dev-OData4_Support-Client-Tools-for-Access"]
 == Client Tools for Access
 
 OData access is really where the user comes in, depending upon your programming model and needs there are various ways you write your access layer into OData. The following are some suggestions:
@@ -266,6 +277,7 @@ OData access is really where the user comes in, depending upon your programming 
 
 For latest information other frameworks and tools available please see http://www.odata.org/ecosystem/
 
+[id="client-dev-OData4_Support-OData-Metadata-How-bookproductnameFull-interprets-the-relational-schema-into-ODatas-metadata"]
 == OData Metadata (How {{ book.productnameFull }} interprets the relational schema into OData's $metadata)
 
 OData defines its schema using Conceptual Schema Definition Language (CSDL). A VDB in an ACTIVE state in {{ book.productnameFull }} exposes its visible metadata in CSDL format. For example if you want retrieve metadata for your vdb, you need to issue a request like:
@@ -342,6 +354,7 @@ Geography and Geometry will be mapped to the corresponding Edm.GeometryXXX and E
 
 Where possible array types will be mapped to a collection type.  However multidimensional arrays are not supported.  Also array/collection values cannot be used as parameters nor in comparisons.
 
+[id="client-dev-OData4_Support-Functions-And-Actions"]
 === Functions And Actions
 
 The mapping of entities and their properties is relatively straight-forward.  The mapping of {{ book.productnameFull }} procedures to OData Functions and Actions is more involved.  Virtual procedures, source procedure, and virtual functions defined by DDL (not a Java class) are all eligible to be mapped.  Source functions or virtual functions defined by a Java class are currently not mapped to corresponding OData constructs - please log an issue if you need that functionality.  OData does not have an out parameter concept, thus OUT parameters are ignored, and INOUT parameters are treated only as IN.  A result set is mapped to a complex type collection result. An array result will be mapped to a simple type collection.
@@ -360,6 +373,7 @@ Currently only unbounded Functions and Actions are supported.
 
 You should always consult the $metadata about Functions and Actions to validate how the procedures/functions were mapped.
 
+[id="client-dev-OData4_Support-OpenAPI-Metadata"]
 == OpenAPI Metadata
 
 An https://issues.redhat.com/browse/TEIID-5555[experimental feature] is available to automatically provide a Swagger 2.0 / https://www.openapis.org/[OpenAPI] metadata via [swagger|openapi].json rather than $metadata.

--- a/client-dev/OData_Support.adoc
+++ b/client-dev/OData_Support.adoc
@@ -1,5 +1,7 @@
+[id="client-dev-OData_Support-OData-Support"]
 = OData Support
 
+[id="client-dev-OData_Support-What-is-OData"]
 == What is OData
 
 The Open Data Protocol (OData) is a Web protocol for querying and updating data that provides a way to unlock your data and free it from silos that exist in applications today. OData does this by applying and building upon Web technologies such as HTTP, Atom Publishing Protocol (AtomPub) and JSON to provide access to information from a variety of applications, services, and stores. The protocol emerged from experiences implementing AtomPub clients and servers in a variety of products over the past several years. OData is used to expose and access information from a variety of sources including, but not limited to, relational databases, file systems, content management systems and traditional Web sites.
@@ -8,6 +10,7 @@ OData is consistent with the way the Web works - it makes a deep commitment to U
 
 copied from http://odata.org[http://odata.org]
 
+[id="client-dev-OData_Support--bookproductnameFull-Support-for-OData"]
 == {{ book.productnameFull }} Support for OData
 
 {{ book.productnameFull }} provides link:OData4_Support.adoc[OData Version 4.0] support.

--- a/client-dev/Partial_Results_Mode.adoc
+++ b/client-dev/Partial_Results_Mode.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Partial_Results_Mode-Partial-Results-Mode"]
 = Partial Results Mode
 
 The {{ book.productnameFull }} Server supports a "partial results" query mode. This mode changes the behavior of the query processor so the server returns results even when some data sources are unavailable.

--- a/client-dev/Prepared_Statements.adoc
+++ b/client-dev/Prepared_Statements.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Prepared_Statements-Prepared-Statements"]
 = Prepared Statements
 
 {{ book.productnameFull }} provides a standard implementation of `java.sql.PreparedStatement`. PreparedStatements can be very important in speeding up common statement execution, since they allow the server to skip parsing, resolving, and planning of the statement. See the Java documentation for more information on http://download.oracle.com/javase/6/docs/technotes/guides/jdbc/getstart/preparedstatement.html#1000039[PreparedStatement usage].

--- a/client-dev/QGIS_Integration.adoc
+++ b/client-dev/QGIS_Integration.adoc
@@ -1,8 +1,10 @@
+[id="client-dev-QGIS_Integration-QGIS-Integration"]
 = QGIS Integration
 
 link:http://www.qgis.org/[QGIS] is an open source geospatial platform.  It can be integrated with {{ book.productnameFull }} to serve geospatial
  data from a variety of sources.
 
+[id="client-dev-QGIS_Integration-Prerequisites"]
 == Prerequisites
 
 - Have QGIS installed.  {{ book.productnameFull }} integration was last tested with version 2.14. 
@@ -15,6 +17,7 @@ for PostGIS/PostgreSQL to be used.
 geometry columns have the appropriate srid and coord_dimensions, which may require setting the {http://www.teiid.org/translator/spatial/2015}srid and {http://www.teiid.org/translator/spatial/2015}coord_dimension
 extension property on the geometry column. 
 
+[id="client-dev-QGIS_Integration-QGIS-Configuration"]
 == QGIS Configuration
 
 This process will need to be repeated for each VDB schema you are exposing that contains geospatial data.
@@ -26,6 +29,7 @@ character '\' as PostgreSQL to properly respond to metadata queries.  Either the
 org.teiid.backslashDefaultMatchEscape must be set to true.
 . Follow the typical QGIS instructions for creating a Layer by browsing to the appropriate schema and selecting a table that exposes a geometry.
 
+[id="client-dev-QGIS_Integration-Additional-Considerations"]
 == Additional Considerations
 
 - If you are integrating a PostgreSQL source, you must not re-expose the postgres system tables including the PostGIS geometry_columns or geography_columns tables.

--- a/client-dev/Reauthentication.adoc
+++ b/client-dev/Reauthentication.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Reauthentication-Reauthentication"]
 = Reauthentication
 
 {{ book.productnameFull }} allows for connections to be reauthenticated so that the identity on the connection can be changed rather than creating a whole new connection.  If using JDBC, see the changeUser link:Connection_Extensions.adoc[Connection extension].  If using ODBC, or simply need a statement based mechanism for reauthentication, see also the link:SET_Statement.adoc[SET Statement] for SESSION AUTHORIZATION.

--- a/client-dev/Request_Level_Transactions.adoc
+++ b/client-dev/Request_Level_Transactions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Request_Level_Transactions-Request-Level-Transactions"]
 = Request Level Transactions
 
 Request level transactions are used when the request is not in the scope of a global or local transaction, which implies "autoCommit" is "true". In a request level transaction, your application does not need to explicitly call commit or rollback, rather every command is assumed to be its own transaction that will automatically be committed or rolled back by the server.
@@ -13,6 +14,7 @@ You can set your transaction wrapping to one of the following modes:
 2.  _OFF_: This mode never automatically wraps a command in a transaction or check whether it needs to wrap a command. This mode can be dangerous as it will allow multiple source updates outside of a transaction without an error. This mode has best performance for applications that do not use updates or transactions.
 3.  _DETECT_: This mode assumes that the user does not know to execute multiple source updates in a transaction. The {{ book.productnameFull }} Server checks every command to see whether it is a multiple source update and wraps it in a transaction. If it is single source then uses the source level command transaction. You can set the transaction mode as a property when you establish the Connection or on a per-query basis using the execution properties. For more information on execution properties, see the section link:Execution_Properties.adoc[Execution Properties]
 
+[id="client-dev-Request_Level_Transactions-Multiple-Insert-Batches"]
 == Multiple Insert Batches
 
 When issuing an INSERT with a query expression (or the deprecated SELECT INTO), multiple insert batches handled by separate source INSERTS may be processed by the {{ book.productnameFull }} server. Care should be taken to ensure that targeted sources support XA or that compensating actions are taken in the event of a failure.

--- a/client-dev/Restrictions.adoc
+++ b/client-dev/Restrictions.adoc
@@ -1,10 +1,13 @@
 
+[id="client-dev-Restrictions-Restrictions"]
 = Restrictions
 
+[id="client-dev-Restrictions-Application-Restrictions"]
 == Application Restrictions
 
 The use of global, local, and request level transactions are all mutually exclusive. Request level transactions only apply when not in a global or local transaction. Any attempt to mix global and local transactions concurrently will result in an exception.
 
+[id="client-dev-Restrictions-Enterprise-Information-System-EIS-Support"]
 == Enterprise Information System (EIS) Support
 
 The underlying data source that represent the EIS system and the EIS system itself must support XA transactions if they want to participate in distributed XA transaction through {{ book.productnameFull }}. If source system does not support the XA, then it can not fully participate in the distributed transaction. However, the source is still eligible to participate in data integration without the XA support.

--- a/client-dev/ResultSet_Extensions.adoc
+++ b/client-dev/ResultSet_Extensions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-ResultSet_Extensions-ResultSet-Extensions"]
 = ResultSet Extensions
 --------------------
 

--- a/client-dev/ResultSet_Limitations.adoc
+++ b/client-dev/ResultSet_Limitations.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-ResultSet_Limitations-ResultSet-Limitations"]
 = ResultSet Limitations
 
 * TYPE_SCROLL_SENSITIVE is not supported.

--- a/client-dev/SET_Statement.adoc
+++ b/client-dev/SET_Statement.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-SET_Statement-SET-Statement"]
 = SET Statement
 
 Execution properties may also be set on the connection by using the SET statement. The SET statement is not yet a language feature of {{ book.productnameFull }} and is handled only in the JDBC client.  Since a JDBC clients backs the pg/ODBC transport, it will work there as well.

--- a/client-dev/SHOW_Statement.adoc
+++ b/client-dev/SHOW_Statement.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-SHOW_Statement-SHOW-Statement"]
 = SHOW Statement
 
 The SHOW statement can be used to see a varitey of information. The SHOW statement is not yet a language feature of {{ book.productnameFull }} and is handled only in the JDBC client.

--- a/client-dev/SQLAlchemy_Integration.adoc
+++ b/client-dev/SQLAlchemy_Integration.adoc
@@ -1,7 +1,9 @@
+[id="client-dev-SQLAlchemy_Integration-SQLAlchemy-Integration"]
 = SQLAlchemy Integration
 
 link:http://www.sqlalchemy.org/[SQLAlchemy] is an open source SQL toolkit and ORM for Python.  
 
+[id="client-dev-SQLAlchemy_Integration-Prerequisites"]
 == Prerequisites
 
 - Have SQLAlchemy installed installed.  {{ book.productnameFull }} integration was last tested with version 1.1.6. 
@@ -9,6 +11,7 @@ link:http://www.sqlalchemy.org/[SQLAlchemy] is an open source SQL toolkit and OR
 - Your {{ book.productnameFull }} installation should already be setup for link:../admin/Socket_Transports.adoc[ODBC] access.  This allows the built-in support of SQLAlchemy 
 for PostgreSQL to be used.
 
+[id="client-dev-SQLAlchemy_Integration-Usage"]
 == Usage
 
 You should be able to use a SQLAlchemy engine for querying.  Reflective import of most table metadata is also supported.
@@ -27,14 +30,17 @@ meta = MetaData()
 test = Table('public.test', meta, autoload=True, autoload_with=engine,postgresql_ignore_search_path=True)
 ----
 
+[id="client-dev-SQLAlchemy_Integration-Limitations"]
 == Limitations
 
 Only a subset of the PostgreSQL dialect is supported.  The primary intent is to allow querying through {{ book.productnameFull }}.  If there are additional features that are needed, please log an enhancement request.
 
 Column metadata will not be available for tables that contain the period '.' character.  Depending upon your needs, you may need import settings that use simple {{ book.productnameFull }} names and not source schema qualified names.
 
+[id="client-dev-SQLAlchemy_Integration-Application-Support"]
 == Application Support
 
+[id="client-dev-SQLAlchemy_Integration-Superset"]
 === Superset
 
 link:http://airbnb.io/superset/[Superset] is an open source data visualization and dashboard builder.  It uses SQLAlchemy to access relational sources.  

--- a/client-dev/SSL_Client_Connections.adoc
+++ b/client-dev/SSL_Client_Connections.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-SSL_Client_Connections-Client-SSL-Settings"]
 == Client SSL Settings
 
 The following sections define the properties required for each SSL mode. Note that when connecting to {{ book.productnameFull }} Server with SSL enabled, you _MUST_ use the _"mms"_ protocol, instead of "mm" in the JDBC connection URL, for example
@@ -17,6 +18,7 @@ There are two different sets of properties that a client can configure to enable
 See also the link:../security/Teiid_Server_Transport_Security.adoc[{{ book.productnameFull }} Server Transport Security] chapter if you are responsible for configuring the server as well.
 {% endif %}
 
+[id="client-dev-SSL_Client_Connections-Option-1-Java-SSL-properties"]
 === Option 1: Java SSL properties
 
 These are standard Java defined system properties to configure the SSL under any JVM, {{ book.productnameFull }} is not unique in its use of SSL. Provide the following system properties to the client VM process.
@@ -39,6 +41,7 @@ These are standard Java defined system properties to configure the SSL under any
 -Djavax.net.ssl.keyStroreType=<keystore type> (optional)
 ----
 
+[id="client-dev-SSL_Client_Connections-Option-2-bookproductnameFull-Specific-Properties"]
 === Option 2: {{ book.productnameFull }} Specific Properties
 
 Use this option when the above "javax" based properties are already in use by the host process. For example if your client application is a Tomcat process that is configured for https protocol and the above Java based properties are already in use, and importing {{ book.productnameFull }}-specific certificate keys into those https certificate keystores is not allowed.

--- a/client-dev/Standalone_Application.adoc
+++ b/client-dev/Standalone_Application.adoc
@@ -1,8 +1,10 @@
 
+[id="client-dev-Standalone_Application-Standalone-Application"]
 = Standalone Application
 
 To use either Driver or DataSource based connections, add the client JAR to your Java client application’s classpath. See the simple client example in the kit for a full Java sample of the following.
 
+[id="client-dev-Standalone_Application-Driver-Connection"]
 == Driver Connection
 
 Sample Code:
@@ -17,6 +19,7 @@ public class {{ book.productnameFull }}Client {
 }
 ----
 
+[id="client-dev-Standalone_Application-Datasource-Connection"]
 === Datasource Connection
 
 Sample Code:

--- a/client-dev/Statement_Extensions.adoc
+++ b/client-dev/Statement_Extensions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Statement_Extensions-Statement-Extensions"]
 = Statement Extensions
 
 The {{ book.productnameFull }} statement extension interface, `org.teiid.jdbc.TeiidStatement`, provides functionality beyond the JDBC standard. To use the extension interface, simply cast or unwap the statement returned by the Connection. The following methods are provided on the extension interface:

--- a/client-dev/Transactions.adoc
+++ b/client-dev/Transactions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Transactions-Transactions"]
 = Transactions
 
 {{ book.productnameFull }} supports three types of transactions from a client perspective:

--- a/client-dev/Unsupported_Classes_and_Methods_in_java.sql.adoc
+++ b/client-dev/Unsupported_Classes_and_Methods_in_java.sql.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Unsupported_Classes_and_Methods_in_java.sql-Unsupported-Classes-and-Methods-in-javasql"]
 = Unsupported Classes and Methods in "java.sql"
 
 |===

--- a/client-dev/Unsupported_Classes_and_Methods_in_javax.sql.adoc
+++ b/client-dev/Unsupported_Classes_and_Methods_in_javax.sql.adoc
@@ -1,3 +1,4 @@
+[id="client-dev-Unsupported_Classes_and_Methods_in_javax.sql-Unsupported-Classes-and-Methods-in-javaxsql"]
 = Unsupported Classes and Methods in "javax.sql"
 
 |===

--- a/client-dev/Unsupported_JDBC_Methods.adoc
+++ b/client-dev/Unsupported_JDBC_Methods.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Unsupported_JDBC_Methods-Unsupported-JDBC-Methods"]
 = Unsupported JDBC Methods
 
 Based upon the JDBC in JDK 1.6, this appendix details only those JDBC methods that {{ book.productnameFull }} does not support. Unless specified below, {{ book.productnameFull }} supports all other JDBC Methods.

--- a/client-dev/Using_Global_Transactions.adoc
+++ b/client-dev/Using_Global_Transactions.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-Using_Global_Transactions-Using-Global-Transactions"]
 = Using Global Transactions
 
 Global or client XA transactions are only applicable to JDBC clients. They all the client to coordinate multiple resources in a single transaction. To take advantage of XA transactions on the client side, use the `{{ book.productnameFull }}DataSource` (or {{ book.productnameFull }} Embedded with transaction detection enabled).

--- a/client-dev/Using_Multiple_Hosts.adoc
+++ b/client-dev/Using_Multiple_Hosts.adoc
@@ -1,14 +1,17 @@
 
+[id="client-dev-Using_Multiple_Hosts-Using-Multiple-Hosts"]
 = Using Multiple Hosts
 
 A group of {{ book.productnameFull }} Servers in the same {{ book.asName }} cluster may be connected using failover and load-balancing features.
 
+[id="client-dev-Using_Multiple_Hosts-External-HA-Load-Balancers"]
 == External HA / Load Balancers
 
 You may choose to use an external tcp load balancer, such as https://www.haproxy.org/[haproxy]. The {{ book.productnameFull }} driver/DataSource should then typically be configured to just use the single host/port of your load balancer.
 
 Even if you configure the load balancer to redirect when there is a failed host, that will not maintain the {{ book.productnameFull }} session state.  If you wish to keep the connection alive, then use the _autoFailover_ feature discussed below.  Otherwise the other {{ book.productnameFull }} Client Features are not necessary when using an external load balancer.
 
+[id="client-dev-Using_Multiple_Hosts--bookproductnameFull-Client-Features"]
 == {{ book.productnameFull }} Client Features
 
 To enable theses features in their simplest form, the client needs to specify multiple host name and port number combinations on the URL connection string.
@@ -23,6 +26,7 @@ If you are using a DataSource to connect to {{ book.productnameFull }} Server, u
 
 The client will randomly pick one the {{ book.productnameFull }} server from the list and establish a session with that server. If that server cannot be contacted, then a connection will be attempted to each of the remaining servers in random order. This allows for both connection time fail-over and random server selection load balancing.
 
+[id="client-dev-Using_Multiple_Hosts-Fail-Over"]
 === Fail Over
 
 Post connection fail over will be used if the _autoFailover_ connection property on JDBC URL is set to true. Post connection failover works by sending a ping, at most every second, to test the connection prior to use. If the ping fails, a new instance will be selected prior to the operation being attempted.

--- a/client-dev/Using_Teiid_with_EclipseLink.adoc
+++ b/client-dev/Using_Teiid_with_EclipseLink.adoc
@@ -1,10 +1,13 @@
 
+[id="client-dev-Using_Teiid_with_EclipseLink-Using-bookproductnameFull-with-EclipseLink"]
 = Using {{ book.productnameFull }} with EclipseLink
 
+[id="client-dev-Using_Teiid_with_EclipseLink-Overview"]
 == Overview
 
 We can use link:Using_Teiid_with_Hibernate.adoc[{{ book.productnameFull }} with Hibernate], we also have a quick start show how https://github.com/teiid/teiid-wildfly-quickstarts/tree/master/hibernate-on-top-of-teiid[Hibernate on top of {{ book.productnameFull }}]. Both Hibernate and Eclipselink are fully support JSR-317 (JPA 2.0), primary purpose of this document is demonstrate how use {{ book.productnameFull }} with EclipseLink.
 
+[id="client-dev-Using_Teiid_with_EclipseLink-Configuration"]
 == Configuration
 
 For the most part, interacting with {{ book.productnameFull }} VDBs (Virtual Databases) through Eclipselink is no different from working with any other type of data source. First, depending on where your Eclipselink application will reside, either in the same VM as the {{ book.productnameFull }} Runtime or on a separate VM, will determine which jar’s are used.
@@ -33,6 +36,7 @@ You configure EclipseLink (via persistence.xml) as follows:
  <property name="eclipselink.target-database" value="org.teiid.eclipselink.platform.TeiidPlatform"/>
 ----
 
+[id="client-dev-Using_Teiid_with_EclipseLink-Limitations"]
 == Limitations
 
 * Many Eclipselink use cases assume a data source has the ability (with proper user permissions) to process Data Definition Language (DDL) statements like CREATE TABLE and DROP TABLE as well as Data Manipulation Language (DML) statements like SELECT, UPDATE, INSERT and DELETE. {{ book.productnameFull }} can handle a broad range of DML, but does not directly support DDL against a particular source.

--- a/client-dev/Using_Teiid_with_Hibernate.adoc
+++ b/client-dev/Using_Teiid_with_Hibernate.adoc
@@ -1,6 +1,8 @@
 
+[id="client-dev-Using_Teiid_with_Hibernate-Using-bookproductnameFull-with-Hibernate"]
 = Using {{ book.productnameFull }} with Hibernate
 
+[id="client-dev-Using_Teiid_with_Hibernate-Configuration"]
 == Configuration
 
 For the most part, interacting with {{ book.productnameFull }} VDBs (Virtual Databases) through Hibernate is no different from working with any other type of data source.  First, depending on where your Hibernate application will reside, either in the same VM as the {{ book.productnameFull }} Runtime or on a separate VM, will determine which jar’s are used. 
@@ -69,8 +71,10 @@ Note also that since your VDBs will likely contain multiple source and view mode
 </class>
 ----
 
+[id="client-dev-Using_Teiid_with_Hibernate-Identifier-Generation"]
 == Identifier Generation
 
+[id="client-dev-Using_Teiid_with_Hibernate-SEQUENCE-Based-Identity-Generation"]
 === SEQUENCE Based Identity Generation
 If you want use SEQUENCE based Identity generation with {{ book.productnameFull }}, this is supported through the {{ book.productnameFull }}Dialect. When you define a JPA Entity
 
@@ -113,6 +117,7 @@ OPTIONS ("teiid_rel:native-query" 'SELECT customer_seq.NEXTVAL FROM dual', DETER
 
 Then when the Customer entity is inserted, the sequence is used.
 
+[id="client-dev-Using_Teiid_with_Hibernate-TABLE-Based-Idenity-Generation"]
 === TABLE Based Idenity Generation
 If you want use TABLE based Identity generation with {{ book.productnameFull }}, this is supported through the {{ book.productnameFull }}Dialect. When you define a JPA Entity like
 
@@ -152,9 +157,11 @@ INSERT INTO IDGENERATOR(IDKEY, IDVALUE) VALUES ('customer', 100);
 
 such that the IDKEY matches and IDVALUE has a initializer value.
 
+[id="client-dev-Using_Teiid_with_Hibernate-IDENTITY-Based-identity-generation"]
 === IDENTITY Based identity generation
 * GUID and Identity (using generated key retrieval) identifier generation strategy are directly supported.
 
+[id="client-dev-Using_Teiid_with_Hibernate-Limitations"]
 == Limitations
 
 * Many Hibernate use cases assume a data source has the ability (with proper user permissions) to process Data Definition Language (DDL) statements like CREATE TABLE and DROP TABLE as well as Data Manipulation Language (DML) statements like SELECT, UPDATE, INSERT and DELETE. {{ book.productnameFull }} can handle a broad range of DML, but does not directly support DDL against a particular source.

--- a/client-dev/WildFly_DataSource.adoc
+++ b/client-dev/WildFly_DataSource.adoc
@@ -1,4 +1,5 @@
 
+[id="client-dev-WildFly_DataSource--bookasName-DataSource"]
 = {{ book.asName }} DataSource
 
 {{ book.productnameFull }} can be configured as a JDBC data source in a {{ book.asName }} Server to be accessed from JNDI or injected into your JEE applications. Deploying {{ book.productnameFull }} as data source in {{ book.asName }} is exactly same as deploying any other RDBMS resources like Oracle or DB2.
@@ -32,6 +33,7 @@ NOTE: Prior to {{ book.productnameFull }} 8.12.3 a module dependency on sun.jdk 
 
 Based on the type of deployment (XA, driver, or local), the contents of this will be different. See the following sections for more. The data source will then be accessible through the JNDI name specified in the below configuration.
 
+[id="client-dev-WildFly_DataSource-DataSource-Connection"]
 == DataSource Connection
 
 Make sure you know the correct DatabaseName, ServerName, Port number and credentials that are specific to your deployment environment.
@@ -70,6 +72,7 @@ Make sure you know the correct DatabaseName, ServerName, Port number and credent
     </datasources>
 ----
 
+[id="client-dev-WildFly_DataSource-Driver-based-connection"]
 == Driver based connection
 
 You can also use {{ book.productnameFull }}’s JDBC driver class `org.teiid.jdbc.TeiidDriver` to create a data source
@@ -99,6 +102,7 @@ You can also use {{ book.productnameFull }}’s JDBC driver class `org.teiid.jdb
     </datasources>
 ----
 
+[id="client-dev-WildFly_DataSource-Local-JDBC-Connection"]
 == Local JDBC Connection
 
 If you are deploying your client application on the same {{ book.asName }} instance as the {{ book.productnameFull }} runtime is installed, then you will want to configure the connection to by-pass making a socket based JDBC connection. By using a slightly different data source configuration to make a "local" connection, the JDBC API will lookup a local {{ book.productnameFull }} runtime in the same VM.


### PR DESCRIPTION
In order to support cross references in the format:
```
xref:client-dev-ADONET_Integration-ADONet-Integration[]
```
We need to have anchor IDs defined for every heading in a guide. This commit modifies the source files for the Client Dev guide so that every heading gets an associated anchor ID. This makes it possible to cross-reference any heading in the guide using the `xref:anchor-id[]` syntax.