### PR TITLE
Fixed AsciiDoc syntax error in ResultSet_Extensions.adoc

### DIFF
--- a/client-dev/ResultSet_Extensions.adoc
+++ b/client-dev/ResultSet_Extensions.adoc
@@ -1,7 +1,6 @@
 
 [id="client-dev-ResultSet_Extensions-ResultSet-Extensions"]
 = ResultSet Extensions
---------------------
 
 The {{ book.productnameFull }} result set extension interface, `org.teiid.jdbc.TeiidResultSet`, provides functionality beyond the JDBC standard. To use the extension interface, simply cast or unwap a result set returned by a {{ book.productnameFull }} statement. The following methods are provided on the extension interface:
 


### PR DESCRIPTION
With this fix, it is possible to build the entire Client Developer guide in the downstream build system without error. @shawkins Can you verify and merge this PR?

@roldanbob FYI