### PR TITLE
Fix dv reference build

### DIFF
--- a/reference/as_ddl-commands.adoc
+++ b/reference/as_ddl-commands.adoc
@@ -5,7 +5,7 @@
 
 {{ book.productnameFull }} supports a subset of DDL to create or drop temporary tables and to manipulate procedure and view definitions at runtime. 
 It is not currently possible to arbitrarily drop or create non-temporary metadata entries. 
-For information about the DDL statements that you can use to define schemas in a virtual database, see xref:ddl-metadata[DDL metadata].
+For information about the DDL statements that you can use to define schemas in a virtual database, see xref:ddl-metadata-for-schema-objects[DDL metadata].
 
 {% if book.targetWildfly %}
 To make non-temporary metadata updates persistent, you must configure a `MetadataRepository`. 

--- a/reference/as_jdbc-translators.adoc
+++ b/reference/as_jdbc-translators.adoc
@@ -291,8 +291,8 @@ The `teiid_rel:non-prepared` extension metadata property can be set to `false` t
 Be careful in setting this option, because inbound allows for SQL injection attacks if not properly validated. 
 The native query does not need to call a stored procedure. 
 Any SQL that returns a result set that positionally matches the result set that is expected by the physical stored procedure metadata will work. 
-For example on a stored procedure `x` with `teiid_rel:native-query="select c from g where c1 = $1 and c2 = `$$1"'`, the {{ book.productnameFull }} source 
-query ``"CALL x(?)"`` would generate the SQL query ``"select c from g where c1 = ? and c2 = `$1"'``.  
+For example on a stored procedure `x` with `+++teiid_rel:native-query="select c from g where c1 = $1 and c2 = `$$1"'+++`, the {{ book.productnameFull }} source 
+query `+++`"CALL x(?)"`+++` would generate the SQL query `+++`"select c from g where c1 = ? and c2 = `$1"'`+++`.  
 Note that `?` in this example will be replaced with the actual value bound to parameter 1.
 
 .Direct query procedure

--- a/reference/as_translators.adoc
+++ b/reference/as_translators.adoc
@@ -134,7 +134,7 @@ The preceding example overrides the _oracle_ translator and sets the _RequiresCr
 The modified translator is only available in the scope of this VDB.
 As many properties as desired may be overriden together.
 
-See also link:vdb_guide.adoc[VDB Definition].
+See also xref:vdb-properties[VDB Definition].
 
 .Parameterizable native queries
 

--- a/reference/as_updatable-views.adoc
+++ b/reference/as_updatable-views.adoc
@@ -35,7 +35,7 @@ For information about key-preserved tables, see xref:key-preserved-tables[Key-pr
 
 If the default handling is not available or if you want to have an alternative implementation of an `INSERT/UPDATE/DELETE`, 
 you can use update procedures, or triggers, to define procedures to handle the respective operations. 
-For more information see xref:update_procedures_triggers[Update procedures (Triggers)].
+For more information see xref:update-procedures-triggers[Update procedures (Triggers)].
 
 Consider the following example of an inherently updatable denormalized view:
 

--- a/reference/r_actian-vector-translator.adoc
+++ b/reference/r_actian-vector-translator.adoc
@@ -3,7 +3,7 @@
 [id="actian-vector-translator"]
 = Actian Vector translator (actian-vector)
 
-Also see common xref:jdbc_translators[JDBC Translators] information.
+Also see common xref:jdbc-translators[JDBC Translators] information.
 
 The Actian Vector translator, known by the type name *_actian-vector_*, is for use with 
 http://esd.actian.com/Express/readme_HSE_2.0.html[Actian Vector in Hadoop].

--- a/reference/r_aggregate-functions.adoc
+++ b/reference/r_aggregate-functions.adoc
@@ -41,7 +41,7 @@ TEXTAGG(col1, col2 as name DELIMITER '|' HEADER ORDER BY col1)
 in a group (excluding null). The ORDER BY clause cannot reference alias names or use positional ordering.
 * JSONARRAY_AGG(x [xref:order-by-clause[ORDER BY …]]) – creates a JSON array result as a Clob 
 including null value. The ORDER BY clause cannot reference alias names or use positional ordering. 
-For more information, see xref:json_functions[JSONARRAY function].
+For more information, see xref:json-functions[JSONARRAY function].
 
 .Example: Integer value expression
 

--- a/reference/r_apache-phoenix-translator.adoc
+++ b/reference/r_apache-phoenix-translator.adoc
@@ -3,7 +3,7 @@
 [id="apache-phoenix-translator"]
 = Apache Phoenix Translator (phoenix)
 
-Also see common xref:jdbc_translators[JDBC Translators] information.
+Also see common xref:jdbc-translators[JDBC Translators] information.
 
 The Apache Phoenix translator, known by the type name *_phoenix_*, exposes querying functionality to http://hbase.apache.org/[HBase] tables. 
 http://phoenix.apache.org/[Apache Phoenix] is a JDBC SQL interface for HBase that is required for this translator as it pushes down commands into 

--- a/reference/r_conformed-tables.adoc
+++ b/reference/r_conformed-tables.adoc
@@ -17,7 +17,7 @@ Conformed tables are defined by adding the following extension metadata property
 {http://www.teiid.org/ext/relational/2012}conformed-sources
 ----
 
-You can set extension properties in the DDL file by using full xref:ddl_metadata-for-schema-objects[DDL metadata] or alter statements, 
+You can set extension properties in the DDL file by using full xref:ddl-metadata-for-schema-objects[DDL metadata] or alter statements, 
 or at runtime by using the `setProperty` xref:system-schema[system procedure]. 
 The property is expected to be a comma separated list of physical model/schema names.
 

--- a/reference/r_criteria.adoc
+++ b/reference/r_criteria.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // as_sql-support.adoc
 
-[id="criteria"]
+[id="sql-criteria"]
 = Criteria
 
 Criteria can be any of the following items:
@@ -58,8 +58,8 @@ expression [NOT] LIKE pattern [ESCAPE char]
 ----
 
 `LIKE` matches the string expression against the given string pattern. 
-The pattern may contain `%` to match any number of characters, and `_` to match any single character. 
-The escape character can be used to escape the match characters `%` and `_`.
+The pattern may contain `%` to match any number of characters, and `+++_+++` to match any single character. 
+The escape character can be used to escape the match characters `%` and `+++_+++`.
 
 [source,sql]
 ----

--- a/reference/r_date-time-functions.adoc
+++ b/reference/r_date-time-functions.adoc
@@ -156,6 +156,7 @@ but will assume that the startTimeZone is the same as the server process.
 
 .Timestampadd/Timestampdiff
 
+[id="Timestampadd"]
 .Timestampadd
 
 Add a specified interval amount to the timestamp.

--- a/reference/r_ddl-deployment-mode.adoc
+++ b/reference/r_ddl-deployment-mode.adoc
@@ -116,13 +116,13 @@ CREATE SERVER {source-name} [TYPE '{source-type}']
     <key> <value>[,<key>, <value>]*
 ----
 
-|====
+|===
 |Name |Description
 |source-name | Name given to the source's connection.
 |source-type | Not currently used. 
 |translator-name| Name of the translator to be used with this server.
 |options| Currently only resource-name is supported. resource-name provides a way to specify the environmentally dependent (JNDI or bean) name of the source if it differs from the server name.  For example java:/source
-|====
+|===
 
 .Example 3: creating a data source connection to Postgres database
 [source,sql] 

--- a/reference/r_federated-optimizations.adoc
+++ b/reference/r_federated-optimizations.adoc
@@ -3,6 +3,7 @@
 [id="federated-optimizations"]
 = Federated Optimizations
 
+[id="access-patterns"]
 .Access patterns
 
 Access patterns are used on both physical tables and views to specify the need for criteria against a set of columns. 
@@ -37,7 +38,7 @@ Dependent joins can perform some joins much faster by drastically reducing the a
 from the second source and the number of join comparisons that must be performed.
 
 The conditions when a dependent join is used are determined by the query planner based on 
-xref:access_patterns[access patterns], hints, and costing information. 
+xref:access-patterns[access patterns], hints, and costing information. 
 {{ book.productnameFull }} supports the following types of dependent joins:
 
 Join based on in/equality support:: Where the engine will determine how to break up large 
@@ -57,8 +58,8 @@ MAKEDEP(MAX:5000)::: meaning that the dependent join should only be performed if
 the maximum number of values from the independent side.
 MAKENOTDEP:: Prevents the clause from being the dependent side of a join.
 
-These can be placed in either the xref:OPTION_Clause.adoc[OPTION Clause] or directly in the 
-xref:FROM_Clause.html[FROM Clause]. As long as all xref:Federated_Optimizations.adoc#_access_patterns[Access Patterns] 
+These can be placed in either the xref:option-clause[OPTION Clause] or directly in the 
+xref:from-clause[FROM Clause]. As long as all xref:access-patterns[Access Patterns] 
 can be met, the MAKEIND, MAKEDEP, and MAKENOTDEP hints override any use of costing information. MAKENOTDEP supersedes the other hints.
 
 TIP: The MAKEDEP or MAKEIND hints should only be used if the proper query plan is not chosen by default. 
@@ -110,6 +111,7 @@ In a cross-source scenario, this allows for where criteria applied to a single s
 {{ book.productnameFull }} ensures that each pushdown query only projects the symbols required 
 for processing the user query. This is especially helpful when querying through large intermediate view layers.
 
+[id="partial-aggregate-pushdown"]
 .Partial aggregate pushdown
 
 Partial aggregate pushdown allows for grouping operations above multi-source joins and unions 
@@ -235,7 +237,7 @@ The view is partitioned on column x, since the first branch can only be the valu
 NOTE: More advanced or explicit partitioning will be considered for future releases. 
 
 The concept of a partitioned union is used for performing partition-wise joins, in 
-xref:Updatable_Views.adoc[Updatable Views], and xref:Federated_Optimizations.adoc#_partial_aggregate_pushdown[Partial Aggregate Pushdown].
+xref:updatable-views[Updatable Views], and xref:partial-aggregate-pushdown[Partial Aggregate Pushdown].
 These optimizations are also applied when using the multi-source feature as well - 
 which introduces an explicit partitioning column.
 
@@ -264,6 +266,7 @@ In an XML VDB:
 ----  
 {% endif %}
 
+[id="standard-relational-techniques"]
 .Standard relational techniques
 
 {{ book.productnameFull }} also incorporates many standard relational techniques to ensure efficient query plans.

--- a/reference/r_file-translator.adoc
+++ b/reference/r_file-translator.adoc
@@ -14,7 +14,7 @@ The translator is typically used with the `TEXTTABLE` or `XMLTABLE` functions to
 |Encoding
 |The encoding that should be used for CLOBs returned by the getTextFiles procedure. 
 The value should match an encoding known to {{ book.productnameFull }}. 
-For more information, see _TO_CHARS_ and _TO_BYTES_ in xref:string-functions.adoc[String functions].
+For more information, see _TO_CHARS_ and _TO_BYTES_ in xref:string-functions[String functions].
 |The system default encoding.
 
 |ExceptionIfFileNotFound

--- a/reference/r_foreign-temporary-tables.adoc
+++ b/reference/r_foreign-temporary-tables.adoc
@@ -14,7 +14,7 @@ CREATE FOREIGN TEMPORARY TABLE name ... ON schema
 ----
 
 Where the table creation body syntax is the same as a standard CREATE FOREIGN TABLE DDL statement. 
-For more information, see xref:ddl-metadata[DDL metadata]. 
+For more information, see xref:ddl-metadata-for-domains[DDL metadata]. 
 In general, usage of DDL OPTION clauses might be required to properly access the source table, 
 including setting the name in the source, updatability, native types, and so forth.
 

--- a/reference/r_literals.adoc
+++ b/reference/r_literals.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // as_expressions.adoc
-[id="literals]
+[id="literals"]
 = Literals
 
 Literal values represent fixed values. 

--- a/reference/r_local-temporary-tables.adoc
+++ b/reference/r_local-temporary-tables.adoc
@@ -67,4 +67,4 @@ INSERT INTO temp VALUES (1,2,3);
 SELECT a,b,c FROM Src3, temp WHERE Src3.a = temp.b; 
 ----
 
-For more information about using local temporary tables, see xref:virtual_procedures[Virtual procedures].
+For more information about using local temporary tables, see xref:virtual-procedures[Virtual procedures].

--- a/reference/r_loopback-translator.adoc
+++ b/reference/r_loopback-translator.adoc
@@ -6,7 +6,7 @@
 The Loopback translator, known by the type name _loopback_, provides a quick testing solution. 
 It supports all SQL constructs and returns default results, with some configurable behavior.
 
-.*Execution properties* 
+.Execution properties 
 
 |===
 |Name |Description |Default
@@ -31,7 +31,8 @@ the engine will wait the poll interval before polling for the results.
 |DelegateName
 |Set to the name of the translator which is to be mimicked.
 |na 
-|=== 
+
+|===
 
 You can also use the Loopback translator to mimic how a real source query would be formed for a given translator 
 (although loopback will still return dummy data that might not be useful for your situation). 

--- a/reference/r_microsoft-sql-server-translator.adoc
+++ b/reference/r_microsoft-sql-server-translator.adoc
@@ -13,7 +13,7 @@ The SQL Server `DatabaseVersion` property can be set to `2000`, `2005`, `2008`, 
 .Sequence support
 {% if book.targetWildfly or book.targetSpring %}
 
-With {{ book.productnameFull }} 8.5+, sequence operations may be modeled as xref:ddl-metadata[source functions].
+With {{ book.productnameFull }} 8.5+, sequence operations may be modeled as xref:ddl-metadata-for-domains[source functions].
 
 With {{ book.productnameFull }} 10.0+, sequences may be imported automatically xref:jdbc-translators[import properties].
 

--- a/reference/r_microsoft-sql-server-translator.adoc
+++ b/reference/r_microsoft-sql-server-translator.adoc
@@ -16,11 +16,8 @@ The SQL Server `DatabaseVersion` property can be set to `2000`, `2005`, `2008`, 
 With {{ book.productnameFull }} 8.5+, sequence operations may be modeled as xref:ddl-metadata[source functions].
 
 With {{ book.productnameFull }} 10.0+, sequences may be imported automatically xref:jdbc-translators[import properties].
-<<<<<<< HEAD
-{% endif %}
-=======
 
->>>>>>> 16f16ed8ccfcdc976c3327389836a5cc1d609397
+{% endif %}
 
 {% if book.Product %}
 Sequences can be imported automatically. 

--- a/reference/r_oracle-translator.adoc
+++ b/reference/r_oracle-translator.adoc
@@ -50,7 +50,7 @@ ifdef::dv-product[]
 You can import sequences automatically.
 endif::[]
 +
-For more information, see _Importer properties_ in xref:jdbc-translators.adoc[JDBC translators].
+For more information, see _Importer properties_ in xref:jdbc-translators[JDBC translators].
 ifndef::dv-product[]
 {{ book.productnameFull }} 8.4 and Prior Oracle Sequence DDL
 

--- a/reference/r_query-planner.adoc
+++ b/reference/r_query-planner.adoc
@@ -33,7 +33,7 @@ The node structure of the debug plan resembles that of the processing plan, but 
 
 .Canonical plan and all nodes
 
-As described in the xref:planning-overview.[Planning overview], a SQL statement submitted to the query engine is parsed, resolved, 
+As described in the xref:planning-overview[Planning overview], a SQL statement submitted to the query engine is parsed, resolved, 
 validated, and rewritten before it is converted into a canonical plan form. The canonical plan form most closely resembles the 
 initial SQL structure. A SQL select query has the following possible clauses (all but SELECT are optional):  
 WITH, SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT. These clauses are logically executed in the following order:

--- a/reference/r_query-plans.adoc
+++ b/reference/r_query-plans.adoc
@@ -21,7 +21,7 @@ For more information, see _Reading a debug plan_ in xref:query-planner[Query pla
 With the above options, the query plan is available from the Statement object by casting 
 to the `org.teiid.jdbc.TeiidStatement` interface or by using the SHOW PLAN statement. For more information, 
 see _SHOW Statement_ in the Client Developer's Guide. 
-Alternatively you may use the EXPLAIN statement. For more information, see, xref:explain-statement[Explain statement].
+Alternatively you may use the EXPLAIN statement. For more information, see, xref:explain-statements[Explain statement].
 
 [source,java]
 .**Retrieving a query plan using {{ book.productnameFull }} extensions**
@@ -72,7 +72,7 @@ resources:
 ** _Hints and Options_ in the Caching Guide.
 //insert link to Caching Guide
 ** _FROM clause hints_ in xref:from-clause[FROM clause].
-** xref:subquery-optimization.[Subquery optimization].
+** xref:subquery-optimization[Subquery optimization].
 ** xref:federated-optimizations[Federated optimizations].
 
 You can determine all of information in the preceding list from the processing plan. You will typically 
@@ -119,7 +119,7 @@ always false (and whatever tree is underneath). There are no properties for this
 * Dependent procedure execution -- Executes a sub plan using multiple sets of input values.
 * Limit -- Returns a specified number of rows, then stops processing. Also processes an offset if present.
 * XML table -- Evaluates XMLTABLE. The debug plan will contain more information about the XQuery/XPath 
-with regards to their optimization. For more information, see xref:xquer-_optimization[XQuery optimization].
+with regards to their optimization. For more information, see xref:xquery-optimization[XQuery optimization].
 * Text table - Evaluates TEXTTABLE
 * Array table - Evaluates ARRAYTABLE
 * Object table - Evaluates OBJECTTABLE

--- a/reference/r_query-termination.adoc
+++ b/reference/r_query-termination.adoc
@@ -31,7 +31,7 @@ Server-side timeouts start when the query is received by the engine. Network lat
 can delays the processing of I/O work after a client issues the query. The timeout will 
 be cancelled if the first result is sent back before the timeout has ended. 
 For more information about setting the `query-timeout` property for a virtual database, 
-see xref:vdb_guide.adoc[Virtual database properties]. For more information about modifying 
+see xref:vdb-properties[Virtual database properties]. For more information about modifying 
 system properties to set a default query timeout for all queries, see _System properties_ 
 in the Administrator's Guide.
 //Conditionalize link to Admin guide in preceding sentence

--- a/reference/r_security-functions.adoc
+++ b/reference/r_security-functions.adoc
@@ -20,7 +20,7 @@ _roleName_ must be a string, the return type is Boolean.
 
 The two argument form is provided for backwards compatibility. `roleType` is a string and must be `data'.
 
-Role names are case-sensitive and only match {{ book.productnameFull }} xref:data0roles[Data roles]. 
+Role names are case-sensitive and only match {{ book.productnameFull }} xref:data-roles[Data roles]. 
 Foreign/JAAS roles/groups names are not valid for this function, unless there is corresponding data role with the same name.
 
 .MD5

--- a/reference/r_sybase-translator.adoc
+++ b/reference/r_sybase-translator.adoc
@@ -11,7 +11,7 @@ known as Sybase SQL Server, version 12.5 or later.
 
 If you use the default native import, you can avoid exceptions during the retrieval of system table information, if you specify import properties. 
 If errors occur when retrieving table information, specify a `schemaName` or `schemaPattern`, or use `excludeTables` to exclude system tables. 
-For more information about using import properties, see _Importer properties_ in xref:jdbc-translator[JDBC translators].
+For more information about using import properties, see _Importer properties_ in xref:jdbc-translators[JDBC translators].
 
 If the name in the source metadata contains quoted identifiers (such as reserved words, or words that contain characters 
 that would not otherwise be allowed), and you are using a jConnect Sybase driver, you must first configure the connection pool to enable *quoted_identifier*:

--- a/reference/r_update-procedures-triggers.adoc
+++ b/reference/r_update-procedures-triggers.adoc
@@ -18,7 +18,7 @@ Update procedures define the logic for how the update command that you run again
 the individual commands to be executed against the underlying physical sources. 
 Similar to virtual procedures, update procedures have the ability to execute queries or other commands, 
 define temporary tables, add data to temporary tables, walk through result sets, use loops, and use conditional logic.
-For more inmformation about virtual procedures, see xref:Virtual_Procedures.adoc[Virtual procedures].
+For more inmformation about virtual procedures, see xref:virtual-procedures[Virtual procedures].
 
 You can use `INSTEAD OF` triggers on views in a way that is similar to the way that you might use them with traditional databases. 
 You can have only one `FOR EACH ROW` procedure for each `INSERT`, `UPDATE`, or `DELETE` operation against a view. 

--- a/reference/r_where-clause.adoc
+++ b/reference/r_where-clause.adoc
@@ -7,4 +7,4 @@ The WHERE clause defines the criteria to limit the records affected by SELECT, U
 
 The general form of the WHERE is:
 
-* WHERE xref:r_criteria[Criteria]
+* WHERE xref:sql-criteria[Criteria]


### PR DESCRIPTION
With these fixes, it is possible to build the Data Virtualization Reference downstream for the first time. @shawkins Can you take a look at this and check that the updates are Ok?

@roldanbob FYI