### PR TITLE
Add variable to book.json to conditionalize content for product doc

### DIFF
--- a/spring/book.json
+++ b/spring/book.json
@@ -12,6 +12,7 @@
         "archeTypeVersion" : "REPLACE ME",
         "targetWildfly" : false,
         "targetSpring" : true,
+        "targetDVProd" : false,
         "productnameFull" : "Teiid Spring Boot",
         "docUrl" : "https://github.com/teiid/teiid-spring-boot/blob/7.6-1.3.x",
         "odataContext" : "odata"


### PR DESCRIPTION
Add variable `targetDVProd` to Spring version of `book.json` to manage flow of content from community doc to DV product doc. Evaluates to `false` in community version.