### PR TITLE
Fix typos, conditionalize content, and fix formatting in links, tables

### DIFF
--- a/client-dev/Additional_Socket_Client_Settings.adoc
+++ b/client-dev/Additional_Socket_Client_Settings.adoc
@@ -2,7 +2,12 @@
 [id="client-dev-Additional_Socket_Client_Settings-Additional-Socket-Client-Settings"]
 = Additional Socket Client Settings
 
-A "teiid-client-settings.properties" file can be used to configure {{ book.productnameFull }} low level and link:SSL_Client_Connections.html[SSL] socket connection properties. Currently only a single properties file is expected per driver/classloader combination. A sample "teiid-client-settings.properties" file can be found inside the "teiid-<version>-client.jar" file at the root called "teiid-client-settings.orig.properties". To customize the settings, extract this file, make a copy, change the property values accordingly, and place this file in the client application’s classpath before the "teiid-<version>-client.jar" file. Typically clients will not need to adjust the non-SSL properties. For reference the properties are:
+A `teiid-client-settings.properties` file can be used to configure Data Virtualization low level and xref:client-dev-SSL_Client_Connections-Client-SSL-Settings[SSL] connection properties. 
+Currently only a single properties file is expected per driver/classloader combination. 
+A sample `teiid-client-settings.properties` file can be found inside the `teiid-<version>-client.jar` file at the root called `teiid-client-settings.orig.properties`. 
+To customize the settings, extract this file, make a copy, change the property values accordingly, and place this file in the client application’s classpath before the `teiid-<version>-client.jar" file`. 
+Typically clients will not need to adjust the non-SSL properties. 
+The following properties are available:
 
 [source,java]
 ----
@@ -62,4 +67,3 @@ org.teiid.sockets.maxObjectSize=33554432
 ----
 
 NOTE: All properties listed in "teiid-client-settings.properties" can also be set as System or env properties.
-

--- a/client-dev/Connecting_to_a_Teiid_Server.adoc
+++ b/client-dev/Connecting_to_a_Teiid_Server.adoc
@@ -11,25 +11,32 @@ Support for {{ book.productnameFull }} clients and servers older than version 8 
 
 Before you can connect to the {{ book.productnameFull }} Server using the {{ book.productnameFull }} JDBC API, please do following tasks.
 
+
 1.  Install the {{ book.productnameFull }} Server. See the "Admin Guide" for instructions.
 2.  Build a Virtual Database (VDB). Check the "Reference Guide" for instructions on how to build a VDB. If you do not know what VDB is, then start with this http://www.jboss.org/teiid/basics/virtualdatabases.html[document].
 3.  Deploy the VDB into {{ book.productnameFull }} Server. Check link:../admin/Administrators_Guide.adoc[Administrator’s Guide] for instructions.
 4.  Start the {{ book.productnameFull }} Server ({{ book.asName }}), if it is not already running.
 {% endif %}
 
-Once you have the VDB deployed in {{ book.productnameFull }}, client applications can connect to the {{ book.productnameFull }} Server and issue SQL queries against deployed VDB using JDBC API. If you are new to JDBC, see Java’s documentation about http://docs.oracle.com/javase/tutorial/jdbc/index.html[JDBC]. {{ book.productnameFull }} ships with teiid-{{ book.fullVersionNumber }}-jdbc.jar that can be found in the http://teiid.io/teiid_runtimes/teiid_wildfly/downloads/[downloads].
+After you deploy the virtual database, client applications can connect to it and issue SQL queries against it using the JDBC API. If you are new to JDBC, refer to the Java documentation about http://docs.oracle.com/javase/tutorial/jdbc/index.html[JDBC]. {{ book.productnameFull }} ships with `teiid-_VERSION_NUMBER_-jdbc.jar` that is available from the http://teiid.io/teiid_wildfly/downloads/[Teiid.io downloads].
 
-You can also obtain the {{ book.productnameFull }} JDBC from the Maven Repository https://oss.sonatype.org/content/repositories/releases/ using the coordinates:
+{% if book.targetWildfly or book.targetSpring %}
+You can also obtain the {{ book.productnameFull }} JDBC from the Maven repository at https://oss.sonatype.org/content/repositories/releases/ using the coordinates:
+{% else %}
+You can also obtain the {{ book.productnameFull }} JDBC from the Red Hat Maven repository at https://maven.repository.redhat.com/ga/org/teiid/
+{% endif %}
 
-[source,xml]
+[source,xml,subs="+quotes"]
 ----
 <dependency>
   <groupId>org.teiid</groupId>
   <artifactId>teiid</artifactId>
   <classifier>jdbc</classifier>
-  <version>{{ book.fullVersionNumber }}</version>
+  <version>__$versionNumber__</version>
 </dependency>
 ----
+
+where `versionNumber` is the version of the most recent {{book.productnameFull}} release.
 
 Important classes in the client JAR:
 
@@ -41,7 +48,7 @@ Once you have established a connection with the {{ book.productnameFull }} Serve
 [id="client-dev-Connecting_to_a_Teiid_Server-OpenTracing-Support"]
 == OpenTracing compatibility
 
-http://opentracing.io/[OpenTracing] is optional for the client driver.  For remote connections to propagate the span the driver must have the appropriate OpenTracing jars in its classpath.  This can be done via a maven dependency:
+http://opentracing.io/[OpenTracing] is optional for the client driver. For remote connections to propagate the span the driver must have the appropriate OpenTracing jars in its classpath.  This can be done via a maven dependency:
 
 [source,xml]
 ----
@@ -52,8 +59,8 @@ http://opentracing.io/[OpenTracing] is optional for the client driver.  For remo
 </dependency>
 ----
 
-where version.opentracing (0.31 for {{ book.productnameFull }} 11.0) is defined in the project integration bom.  
+where `version.opentracing` is defined in the project integration bom.  
 
-Or you may manually include the opentracing-util, opentracing-api, and opentracing-noop jars as needed by the tooling or other environment where the {{ book.productnameFull }} client jar is utilized.
+Alternately, you can manually include the `opentracing-util`, `opentracing-api`, and `opentracing-noop` jar files as needed by the tooling or other environment where the {{ book.productnameFull }} client jar is utilized.
 
 OpenTracing support in the client and server requires that the respective runtimes have an appropriate tracing client installed and available via the GlobalTracer.

--- a/client-dev/DSN_Less_Connection.adoc
+++ b/client-dev/DSN_Less_Connection.adoc
@@ -16,4 +16,4 @@ For *nix:
 ODBC;DRIVER={PostgreSQL};DATABASE=<vdb-name>;SERVER=<host-name>;PORT=<port>;Uid=<username>;Pwd=<password>;c4=0;c8=1;            
 ----
 
-See the available link:ODBC_Support.adoc#_connection_settings[{{ book.productnameFull }} connection options].
+See the available xref:client-dev-ODBC_Support--bookproductnameFull-Connection-Settings[{{ book.productnameFull }} ODBC connection settings].

--- a/client-dev/Driver_Connection.adoc
+++ b/client-dev/Driver_Connection.adoc
@@ -17,10 +17,10 @@ You should attempt to keep the client up-to-date though as fixes and features ar
 URL Components
 
 1.  <vdb-name> - Name of the VDB you are connecting to. Optionally VDB name can also contain version information inside it. For example: "myvdb.2", this is equivalent to supplying the "version=2" connection property defined below. However, use of vdb name in this format and the "version" property at the same time is not allowed.
-2.  mm - defines {{ book.productnameFull }} JDBC protocol, mms defines a secure channel (see link:SSL_Client_Connections.adoc[SSL Client Connections] for more)
+2.  mm - defines {{ book.productnameFull }} JDBC protocol, mms defines a secure channel (see xref:client-dev-SSL_Client_Connections-Client-SSL-Settings[SSL Client Connections] for more)
 3.  <host> - defines the server where the {{ book.productnameFull }} Server is installed. If you are using IPv6 binding address as the host name, place it in square brackets. ex:[::1]
 4.  <port> - defines the port on which the {{ book.productnameFull }} Server is listening for incoming JDBC connections.
-5.  [prop-name=prop-value] - additionally you can supply any number of name value pairs separated by semi-colon [;]. All compatible URL properties are defined in the link:Driver_Connection.adoc[connection properties] section. Property values should be URL encoded if they contain reserved characters, e.g. (’?’, '=', ';', etc.)
+5.  [prop-name=prop-value] - additionally you can supply any number of name value pairs separated by semi-colon [;]. All compatible URL properties are defined in the xref:client-dev-Driver_Connection-URL-Connection-Properties[connection properties] section. Property values should be URL encoded if they contain reserved characters, e.g. (’?’, '=', ';', etc.)
 
 {% if book.targetWildfly %}
 NOTE: host and port may be a comma separated list to specify link:Using_Multiple_Hosts.adoc[multiple hosts].
@@ -55,7 +55,7 @@ The following table shows all the connection properties that you can use with {{
 
 |`partialResultsMode`
 |`boolean`
-|Enable/disable partial results mode. Default false. See the link:Partial_Results_Mode.adoc[Partial Results Mode] section.
+|Enable/disable partial results mode. Default false. See the xref:client-dev-Partial_Results_Mode-Partial-Results-Mode[Partial Results Mode] section.
 
 |`autoCommitTxn`
 |`String`
@@ -106,6 +106,7 @@ If true in embedded mode, connections will reconnect to a newer VDB of the same 
 |`String`
 |(typically not set as a connection property) Can be ON, OFF; ON prevents query execution, but parsing and planning will still occur. Default OFF.
 
+{% if book.targetWildfly or book.targetSpring %}
 |`PassthroughAuthentication`
 |`boolean`
 |Only applies to "local" connections. When this option is set to "true", then {{ book.productnameFull }} looks for already authenticated security context on the calling thread. If one found it uses that users credentials to create session. {{ book.productnameFull }} also verifies that the same user is using this connection during the life of the connection. if it finds a different security context on the calling thread, it switches the identity on the connection, if the new user is also eligible to log in to {{ book.productnameFull }} otherwise connection fails to execute.
@@ -113,6 +114,7 @@ If true in embedded mode, connections will reconnect to a newer VDB of the same 
 |`useCallingThread`
 |`boolean`
 |Only applies to "local" connections. When this option is set to "true" (the default), then the calling thread will be used to process the query. If false, then an engine thread will be used.
+{% endif %}
 
 |`QueryTimeout`
 |`integer`
@@ -123,13 +125,17 @@ If true in embedded mode, connections will reconnect to a newer VDB of the same 
 |A change was made in JDBC4 to return unaliased column names as the ResultSetMetadata column name. Prior to this, if a column alias were used it was returned as the column name. Setting this property to false
 will enable backwards compatibility with JDBC3 and earlier. Defaults to true.
 
+{% if book.targetWildfly or book.targetSpring %}
 |`jaasName`
 |`String`
 |JAAS configuration name. Only applies when configuring a GSS authentication. Defaults to {{ book.productnameFull }}. See the Security Guide for configuration required for GSS.
 
+
 |`kerberosServicePrincipleName`
 |`String`
 |Kerberos authenticated principle name. Only applies when configuring a GSS authentication. See the Security Guide for configuration required for GSS
+
+{% endif %}
 
 |`encryptRequest`
 |`boolean`
@@ -139,13 +145,15 @@ will enable backwards compatibility with JDBC3 and earlier. Defaults to true.
 |`boolean`
 |In some situations tooling may choose undesirable fetch sizes for processing results. Set to true to disable honoring ResultSet.setFetchSize. Default false.
 
+{% if book.targetWildfly or book.targetSpring %}
 |`loginTimeout`
 |`integer`
 |The login timeout in seconds. Must be >= 0. 0 indicates no specific timeout, but other timeouts may apply. 
 If a connection cannot be created in approximately the the timeout value an exception will be thrown. A default of 0 does not mean that the login
-will wait indefinitely.  Typically is an active vdb cannot be found the login will fail at that time.  Local connections that specify a vdb version however
-can wait by default for up to link:../admin/System_Properties.adoc[org.teiid.clientVdbLoadTimeoutMillis].
-
+will wait indefinitely. Typically if an active vdb cannot be found, the login will fail at that time. 
+Local connections that specify a vdb version however
+can wait by default for up to the time specified in the property link:../admin/System_Properties.adoc[org.teiid.clientVdbLoadTimeoutMillis[org.teiid.clientVdbLoadTimeoutMillis].
+{% endif %}
 |`reportAsViews`
 |`boolean`
 |If DatabaseMetaData will report {{ book.productnameFull }} views as a VIEW table type. If false then {{ book.productnameFull }} views will be reported as a TABLE. Default true.

--- a/client-dev/JDBC_Support.adoc
+++ b/client-dev/JDBC_Support.adoc
@@ -2,9 +2,9 @@
 [id="client-dev-JDBC_Support-JDBC-Support"]
 = JDBC compatibility
 
-{{ book.productnameFull }} provides a robust JDBC driver that implements most of the JDBC API according to the latest specification and compatible Java version. Most tooling designed to work with JDBC should work seamlessly with the {{ book.productnameFull }} driver. When in doubt, see link:Unsupported_JDBC_Methods.adoc[Incompatible JDBC Methods] for functionality that has yet to be implemented.
+{{ book.productnameFull }} provides a robust JDBC driver that implements most of the JDBC API according to the latest specification and compatible Java version. Most tooling designed to work with JDBC should work seamlessly with the {{ book.productnameFull }} driver. When in doubt, see xref:client-dev-Unsupported_JDBC_Methods-Unsupported-JDBC-Methods[Incompatible JDBC Methods] for functionality that has yet to be implemented.
 
-If you’re needs go beyond JDBC, {{ book.productnameFull }} has also provided link:JDBC_Extensions.adoc[JDBC Extensions] for asynch handling, federation, and other features.
+If your needs go beyond JDBC, {{ book.productnameFull }} has also provided xref:client-dev-JDBC_Extensions-JDBC-Extensions[JDBC Extensions] for asynch handling, federation, and other features.
 
 [id="client-dev-JDBC_Support-Generated-Keys"]
 == Generated Keys

--- a/client-dev/Non-blocking_Statement_Execution.adoc
+++ b/client-dev/Non-blocking_Statement_Execution.adoc
@@ -43,9 +43,11 @@ A continuous query must do the following:
 * be executed with a forward-only result set
 * cannot be used in the scope of a transaction
 
-Since resource consumption is expected to be different in a continuous plan, it does not count against the server max active plan limit. Typically custom sources will be used to provide data streams. See the Developer’s Guide, in particular the section on link:../dev/Executing_Commands.adoc[ReusableExecutions] for more.
-
+Since resource consumption is expected to be different in a continuous plan, it does not count against the server max active plan limit. 
+Typically custom sources will be used to provide data streams. 
+{% if book.targetWildfly or book.targetSpring %}
+For more information, see _ReusableExecutions_ in the link:../dev/Executing_Commands.adoc[Developers Guide].
+{% endif %}
 When the client wishes to end the continuous query, the `Statement.close()` or `Statement.cancel()` method should be called.  Typically your callback will close whenever it no long needs to process results.
 
 See also the `ContinuousStatementCallback` for use as the `StatementCallback` for additional methods related to continuous processing.
-

--- a/client-dev/ODBC_Connection_Properties.adoc
+++ b/client-dev/ODBC_Connection_Properties.adoc
@@ -1,20 +1,21 @@
 [id="client-dev-ODBC_Connection_Properties-Configuring-Connection-Properties-with-ODBC"]
 = Configuring Connection Properties with ODBC
 
-When working with ODBC connection, the user can set the connection properties link:Driver_Connection.adoc[Driver Connection#URL Connection Properties] 
-that are available in {{ book.productnameFull }} by executing the command like below.
+When working with ODBC connections, you can set the xref:client-dev-Driver_Connection-URL-Connection-Properties[URL connection properties] 
+that are available in {{ book.productnameFull }} by running a command such as the following:
 
 ----
 SET <property-name> TO <property-value>
 ----  
 
-for example to turn on the result set caching you can issue
+For example, to turn on result set caching you can run the following command:
 
 ----
 SET resultSetCacheMode TO 'true'
 ----
 
-Another option is to set this as VDB property in the vdb file as 
+Another option is to use VDB properties in the vdb file to configure the connection, as in 
+the following example: 
 
 [source,sql]
 ----

--- a/client-dev/ODBC_Support.adoc
+++ b/client-dev/ODBC_Support.adoc
@@ -16,9 +16,9 @@ NOTE: *Handling names with underscore ("_")* in ODBC. By default {{ book.product
 This may cause metadata queries to be issued against objects with "_" in their name to return no or incorrect results.  You may globally emulate the behavior of PostgreSQL by setting the `org.teiid.backslashDefaultMatchEscape` system property to `true`. To alter the property just for the current session then have your ODBC client issue `select cast(teiid_session_set('backslashDefaultMatchEscape', true) as boolean)` statement before any other statement.  
 
 Postgres ODBC drivers 9.5 and later do not require this special property as the client will use an E escaped literal instead.
-
+{% if book.targetWildfly or book.targetSpring %}
 Compatibility was last ensured with the 9.6 Postgres ODBC driver.  You are encouraged to use later client versions when needed and report any issues to the community.
-
+{% endif %}
 [id="client-dev-ODBC_Support-Known-Limitations"]
 == Known Limitations:
 
@@ -50,9 +50,9 @@ If you need secure passwords in transit and are not using SSL, then consider ins
 See the link:../security/Security_Guide.adoc[Security Guide] for details on configuring SSL for and using Kerberos with the pg transport.
 {% endif %}
 
-For a windows client, see the link:Configuring_the_Data_Source_Name_DSN.adoc[Configuring the Data Source Name].
+For a Windows client, see xref:client-dev-Configuring_the_Data_Source_Name_DSN-Configuring-the-Data-Source-Name-DSN[Configuring the Data Source Name].
 
-See also link:DSN_Less_Connection.adoc[DSN Less Connection].
+See also xref:client-dev-DSN_Less_Connection-DSN-Less-Connection[DSN Less Connection].
 
 [id="client-dev-ODBC_Support-Connection-Settings"]
 === Connection Settings
@@ -87,6 +87,6 @@ Any other setting that does have a client side affect, such as "LF <-> CR/LF con
 [id="client-dev-ODBC_Support--bookproductnameFull-Connection-Settings"]
 ==== {{ book.productnameFull }} Connection Settings
 
-Most {{ book.productnameFull }} specific connection properties do not map to ODBC client connection settings. If you find yourself in this situation and cannot use post connection SET statements, then the VDB itself may take default link:ODBC_Connection_Properties.adoc[connection properties] for ODBC. Use VDB properties of the form connection.XXX to control things like partial results mode, result set caching, etc.
+Most {{ book.productnameFull }} specific connection properties do not map to ODBC client connection settings. If you find yourself in this situation and cannot use post connection SET statements, then you can set default xref:client-dev-ODBC_Connection_Properties-Configuring-Connection-Properties-with-ODBC[ODBC connection properties] for the virtual database. Use VDB properties of the form `connection.XXX` to control things like partial results mode, result set caching, etc.
 
 The application name may be set by some clients.  If not, you may use a SET statement - "SET application_name name" - to set the name even after the connection is made.

--- a/client-dev/Prepared_Statements.adoc
+++ b/client-dev/Prepared_Statements.adoc
@@ -2,12 +2,15 @@
 [id="client-dev-Prepared_Statements-Prepared-Statements"]
 = Prepared Statements
 
-{{ book.productnameFull }} provides a standard implementation of `java.sql.PreparedStatement`. PreparedStatements can be very important in speeding up common statement execution, since they allow the server to skip parsing, resolving, and planning of the statement. See the Java documentation for more information on http://download.oracle.com/javase/6/docs/technotes/guides/jdbc/getstart/preparedstatement.html#1000039[PreparedStatement usage].
+{{ book.productnameFull }} provides a standard implementation of `java.sql.PreparedStatement`. 
+PreparedStatements can be very important in speeding up common statement execution, since they allow the server to skip parsing, resolving, and planning of the statement. 
+See the Java documentation for more information on http://download.oracle.com/javase/6/docs/technotes/guides/jdbc/getstart/preparedstatement.html#1000039[PreparedStatement usage].
 
 `PreparedStatement` Considerations
 
 * It is not necessary to pool client side {{ book.productnameFull }} `PreparedStatements`, since {{ book.productnameFull }} performs plan caching on the server side.
-* The number of cached plans is configurable (see the Admin Guide), and are purged by the least recently used (LRU).
+* The number of cached plans is configurable, and cached plans are purged by the least recently used (LRU). 
+{% if book.targetWildfly or book.targetSpring %} For information about configuring cached plans, see the Admin Guide. {% endif %}
 * Cached plans are not distributed through a cluster. A new plan must be created for each cluster member.
 * Plans are cached for the entire VDB or for just a particular session. The scope of a plan is detected automatically based upon the functions evaluated during it’s planning process.
 * Stored procedures executed through a `CallableStatement` have their plans cached just as a `PreparedStatement`.

--- a/client-dev/ResultSet_Extensions.adoc
+++ b/client-dev/ResultSet_Extensions.adoc
@@ -2,7 +2,7 @@
 [id="client-dev-ResultSet_Extensions-ResultSet-Extensions"]
 = ResultSet Extensions
 
-The {{ book.productnameFull }} result set extension interface, `org.teiid.jdbc.TeiidResultSet`, provides functionality beyond the JDBC standard. To use the extension interface, simply cast or unwap a result set returned by a {{ book.productnameFull }} statement. The following methods are provided on the extension interface:
+The {{ book.productnameFull }} result set extension interface, `org.teiid.jdbc.TeiidResultSet`, provides functionality beyond the JDBC standard. To use the extension interface, simply cast or unwrap a result set returned by a {{ book.productnameFull }} statement. The following methods are provided on the extension interface:
 
 .*Connection Properties*
 |===

--- a/client-dev/Unsupported_Classes_and_Methods_in_java.sql.adoc
+++ b/client-dev/Unsupported_Classes_and_Methods_in_java.sql.adoc
@@ -6,7 +6,7 @@
 |Class name |Methods
 
 |`Blob`
-|
+a|
 [source,java]
 ----
 getBinaryStream(long, long) - throws SQLFeatureNotSupportedException
@@ -16,7 +16,7 @@ truncate(long) - throws SQLFeatureNotSupportedException
 ----
 
 |`CallableStatement`
-|
+a|
 [source,java]
 ----
 getObject(int parameterIndex, Map&lt;String, Class&lt;?&gt;&gt; map) - throws SQLFeatureNotSupportedException
@@ -30,7 +30,7 @@ setURL(String parameterName, URL val) - throws SQLFeatureNotSupportedException
 ----
 
 |`Clob`
-|
+a|
 [source,java]
 ----
 getCharacterStream(long arg0, long arg1) - throws SQLFeatureNotSupportedException
@@ -41,7 +41,7 @@ truncate - throws SQLFeatureNotSupportedException
 ----
 
 |`Connection`
-|
+a|
 [source,java]
 ----
 createBlob - throws SQLFeatureNotSupportedException
@@ -59,7 +59,7 @@ setRealOnly - effectively ignored
 ----
 
 |`DatabaseMetaData`
-|
+a|
 [source,java]
 ----
 getAttributes - throws SQLFeatureNotSupportedException
@@ -71,7 +71,7 @@ getRowIdLifetime - throws SQLFeatureNotSupportedException
 |`Not Supported`
 
 |`PreparedStatement`
-|
+a|
 [source,java]
 ----
 setRef - throws SQLFeatureNotSupportedException
@@ -83,7 +83,7 @@ setUnicodeStream - throws SQLFeatureNotSupportedException
 |`Not Implemented`
 
 |`ResultSet`
-|
+a|
 [source,java]
 ----
 deleteRow - throws SQLFeatureNotSupportedException


### PR DESCRIPTION
Conditonalize content for downstream use, fix broken links, some version references, typos, and bad code block formatting in tables. 